### PR TITLE
feat(data): add Kimchi.dev $50 Serverless AI Credit bansos

### DIFF
--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -170,8 +170,9 @@ export const bansosList: BansosItem[] = [
 		},
 		ctaLink: 'https://kimchi.dev',
 		tags: [
-			'AI',
+			'AI Credits',
 			'Serverless',
+			'No Credit Card',
 			'Gratisan'
 		],
 		featured: false,

--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -149,6 +149,34 @@ export const bansosList: BansosItem[] = [
 		featured: false,
 		status: 'active'
 	}
+	,
+	{
+		id: 'kimchi-dev-serverless-ai',
+		title: 'Kimchi.dev $50/Bulan Serverless AI Credit',
+		provider: 'Kimchi.dev',
+		description: 'Dapatkan saldo Serverless AI sebesar $50 setiap bulan dari Kimchi.dev secara gratis tanpa syarat kartu kredit. Cocok bagi developer yang ingin bereksperimen dan membangun aplikasi AI.',
+		benefits: [
+			'$50 Serverless AI credit per bulan',
+			'Tanpa syarat kartu kredit'
+		],
+		validity: 'Selamanya',
+		requirements: [
+			'Daftar akun di Kimchi.dev',
+			'Verifikasi alamat email'
+		],
+		contributor: {
+			name: 'DevERS',
+			url: 'https://renzlab.my.id'
+		},
+		ctaLink: 'https://kimchi.dev',
+		tags: [
+			'AI',
+			'Serverless',
+			'Gratisan'
+		],
+		featured: false,
+		status: 'active'
+	}
 ];
 
 export const latestBansos = (limit = 3) => bansosList.slice(-limit).reverse();


### PR DESCRIPTION
## Ringkasan Perubahan

Menambahkan informasi baru untuk **Kimchi.dev ($50/Bulan Serverless AI Credit)** ke dalam daftar bansos.

Website ini menyediakan kredit senilai $50 setiap bulannya secara gratis tanpa mewajibkan kartu kredit (*no CC required*).
Telah dilakukan pengujian pendaftaran, dan terverifikasi bahwa akun berhasil mendapatkan alokasi kredit $50/bulan. Hal ini dipastikan sebagai program dan *benefit* resmi yang disediakan langsung melalui situs web Kimchi.dev.