### PR TITLE
feat: add Kie.ai API credit bansos

### DIFF
--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -178,6 +178,44 @@ export const bansosList: BansosItem[] = [
 		featured: false,
 		status: 'active'
 	}
+	,
+	{
+		id: 'kie-ai-api-discount-credit',
+		title: 'Kie.ai Free Credit & API Lebih Murah buat AI Builder',
+		provider: 'Kie.ai',
+		description: 'Kie.ai sering ngasih gratisan credit buat developer yang mau ngoprek AI image, video, dan text API. Selain itu pricing API-nya bisa jauh lebih murah dari official, cocok buat eksperimen tanpa bikin dompet langsung tumbang.',
+		benefits: [
+			'Umumnya ada free credit berkala/bulanan untuk akun aktif',
+			'Promo dan harga API bisa 30–50% lebih murah dari official pada beberapa model',
+			'Beberapa pricing comparison di dashboard menampilkan diskon sampai sekitar 70%',
+			'Menyediakan AI Image API, AI Video API, dan AI Text API dalam satu marketplace',
+			'Cocok buat prototype produk AI sebelum scale ke production'
+		],
+		validity: 'Selama promo/free credit Kie.ai masih tersedia; cek dashboard setelah daftar',
+		requirements: [
+			'Daftar akun Kie.ai lewat link referral',
+			'Login ke dashboard dan cek saldo/credit akun',
+			'Masuk ke API Market atau Pricing untuk cek model dan harga terbaru',
+			'Buat API key kalau mau integrasi ke aplikasi',
+			'Manfaatkan free credit dan bandingkan pricing sebelum top-up'
+		],
+		tips: 'Cek dashboard secara berkala karena free credit dan promo bisa berubah. Jangan expose API key di frontend; pakai env/server-side proxy biar aman.',
+		contributor: {
+			name: 'Pena Digital',
+			url: 'https://penadigital.tech/'
+		},
+		ctaLink: 'https://kie.ai?ref=2d0ecbdedae3034bdaee48fc726309be',
+		tags: [
+			'AI Credits',
+			'API',
+			'AI Image',
+			'AI Video',
+			'Diskon',
+			'Gratisan'
+		],
+		featured: false,
+		status: 'active'
+	}
 ];
 
 export const latestBansos = (limit = 3) => bansosList.slice(-limit).reverse();

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -7,18 +7,6 @@
 		selectedTag === 'Semua' ? bansosList : getBansosByTag(selectedTag)
 	);
 
-	function spawnEmoji(e: MouseEvent, text: string) {
-		const emoji = {
-			id: Math.random(),
-			x: e.clientX,
-			y: e.clientY,
-			text
-		};
-		floatingEmojis = [...floatingEmojis, emoji];
-		setTimeout(() => {
-			floatingEmojis = floatingEmojis.filter((i) => i.id !== emoji.id);
-		}, 1000);
-	}
 </script>
 
 <svelte:head>
@@ -51,7 +39,7 @@
 		<button class:active={selectedTag === 'Semua'} onclick={() => (selectedTag = 'Semua')}>
 			Semua
 		</button>
-		{#each allBansosTags as tag}
+		{#each allBansosTags as tag (tag)}
 			<button class:active={selectedTag === tag} onclick={() => (selectedTag = tag)}>
 				{tag}
 			</button>


### PR DESCRIPTION
## What changed
- Add Kie.ai as a new bansos entry with free credit/promo API positioning.
- Include Pena Digital as contributor and referral CTA link.
- Remove stale unused emoji handler on the list page and key the tag loop so `svelte-check` passes.

## Validation
- `npm run check`
- `npm run build`
- `npx eslint src/lib/data/bansos.ts src/routes/list/+page.svelte`

## Manual check
- Built static page includes `/list/kie-ai-api-discount-credit/`.
- Sitemap includes the new Kie.ai detail page.
