### PR TITLE
feat: improve bansos list sorting and contributor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Website statis berisi daftar program bantuan dan promo untuk developer, dirancan
 
 - Landing page + daftar bansos yang mudah dinavigasi.
 - Konten SEO: meta tag, OG/Twitter card, dan JSON-LD.
-- Data terstruktur di [`src/lib/data/bansos.ts`](/Users/wauputra/Documents/02_Bisnis_Pekerjaan/07_Dev/bansos.dev/src/lib/data/bansos.ts).
+- Data terstruktur di [`src/lib/data/bansos.json`](/Users/wauputra/Documents/02_Bisnis_Pekerjaan/07_Dev/bansos.dev/src/lib/data/bansos.json).
 - UI modular, filter tag, dan highlight terbaru.
 - Workflow otomatis untuk menambah data lewat CLI.
 
@@ -21,9 +21,7 @@ npm run build
 
 ## Cara menambah bansos
 
-Ada 3 cara
-
-### 1) Contributor biasa (tanpa token)
+Contributor cukup pakai CLI, nanti akan muncul URL issue GitHub siap-submisi:
 
 Jalankan command berikut, nanti CLI akan membalikin URL issue GitHub siap-submisi:
 
@@ -42,21 +40,13 @@ npx bansosdev add \
   --contributor-url "https://example.com"
 ```
 
-### 2) Cek payload (tanpa side effect)
+### Cek payload
 
 ```bash
 npx bansosdev add ... --mode json
 ```
 
-### 3) Maintainer (langsung ke repo)
-
-```bash
-BANSOSDEV_GITHUB_TOKEN=ghp_xxx npx bansosdev add ... --mode direct
-```
-
-Catatan: token harus punya akses untuk `contents: write` dan dapat dispatch workflow.
-
-### 4) Lokal (fallback internal)
+### Lokal
 
 ```bash
 npm run add:bansos -- \
@@ -89,7 +79,8 @@ Lihat panduan kontribusi di [CONTRIBUTING](.github/CONTRIBUTING.md).
 
 MIT. Lihat [LICENSE](LICENSE).
 
-## Kredit
+## Contributors
 
-- Wauputra — [threads.net/@wauputra](https://www.threads.net/@wauputra)
-- GitHub: [github.com/wauputr4/bansos](https://github.com/wauputr4/bansos)
+<a href="https://github.com/wauputr4" target="_blank" rel="noopener noreferrer">
+  <img src="https://github.com/wauputr4.png?size=80" width="64" height="64" alt="@wauputr4" />
+</a>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Website statis berisi daftar program bantuan dan promo untuk developer, dirancan
 
 - Landing page + daftar bansos yang mudah dinavigasi.
 - Konten SEO: meta tag, OG/Twitter card, dan JSON-LD.
-- Data terstruktur di [`src/lib/data/bansos.json`](/Users/wauputra/Documents/02_Bisnis_Pekerjaan/07_Dev/bansos.dev/src/lib/data/bansos.json).
+- Data terstruktur di [`src/lib/data/bansos.json`](src/lib/data/bansos.json).
 - UI modular, filter tag, dan highlight terbaru.
 - Workflow otomatis untuk menambah data lewat CLI.
 

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -11,13 +11,13 @@
 			"Berlaku dari tanggal 8–30 Juni 2026"
 		],
 		"promoCode": "DEVWEEK26",
-		"validity": "8–30 Juni 2026",
+		"validity": "Sudah tidak aktif (promo code tidak bisa digunakan lagi)",
 		"requirements": [
 			"Punya akun Name.com aktif",
 			"Pilih domain .dev atau .app yang tersedia",
 			"Gunakan promo code pas checkout"
 		],
-		"tips": "Cuma bisa 1 akun per orang! Jangan coba-coba tuyul akun ya dek ya, biar berkah dan websitenya awet.",
+		"tips": "Promo ini sudah tidak aktif dan promo code tidak bisa dipakai lagi. Tetap disimpan sebagai arsip bansos biar developer lain gak buang waktu nyobain kode yang sudah wafat.",
 		"contributor": {
 			"name": "Wauputra",
 			"url": "https://wau.my.id"
@@ -25,7 +25,7 @@
 		"ctaLink": "https://www.name.com",
 		"tags": ["Domain", "Gratisan", "No Credit Card"],
 		"featured": true,
-		"status": "active"
+		"status": "expired"
 	},
 	{
 		"id": "tokenrouter-model-gateway",

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -8,7 +8,7 @@
 			"Domain .dev dan .app gratis tanpa bayar sama sekali",
 			"Tidak perlu kartu kredit (Anti-CC-ribet-club)",
 			"Limit 1 domain per akun (Biar semua kebagian, fr fr)",
-			"Berlaku dari tanggal 8–30 Juni 2026"
+			"Status arsip: promo code DEVWEEK26 sudah tidak bisa digunakan lagi"
 		],
 		"promoCode": "DEVWEEK26",
 		"validity": "Sudah tidak aktif (promo code tidak bisa digunakan lagi)",

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -40,6 +40,7 @@
 
 	let selectedTags: string[] = $state([]);
 	let selectedStatuses: string[] = $state([]);
+	let sortOrder: 'newest' | 'oldest' = $state('newest');
 	let filterExpanded = $state(false);
 	let floatingEmojis: { id: number; x: number; y: number; icon: string; color?: string }[] = $state(
 		[]
@@ -51,17 +52,17 @@
 		)
 	);
 
-	const statusOrder: Record<string, number> = { active: 1, upcoming: 2, expired: 3 };
-
 	const filteredBansos = $derived(
 		bansosState.data
-			.filter((item) => {
+			.map((item, index) => ({ item, index }))
+			.filter(({ item }) => {
 				const tagMatch =
 					selectedTags.length === 0 || item.tags.some((tag) => selectedTags.includes(tag));
 				const statusMatch = selectedStatuses.length === 0 || selectedStatuses.includes(item.status);
 				return tagMatch && statusMatch;
 			})
-			.sort((a, b) => statusOrder[a.status] - statusOrder[b.status])
+			.sort((a, b) => (sortOrder === 'newest' ? b.index - a.index : a.index - b.index))
+			.map(({ item }) => item)
 	);
 
 	const totalSeconds = $derived(Math.ceil(remainingTime / 1000));
@@ -188,6 +189,26 @@
 
 				<div class="filter-dropdown">
 					<div class="filter-group">
+						<h3 class="filter-group-title">Urutan</h3>
+						<div class="tag-grid">
+							<button
+								class="tag-btn"
+								class:active={sortOrder === 'newest'}
+								onclick={() => (sortOrder = 'newest')}
+							>
+								Terbaru
+							</button>
+							<button
+								class="tag-btn"
+								class:active={sortOrder === 'oldest'}
+								onclick={() => (sortOrder = 'oldest')}
+							>
+								Terlama
+							</button>
+						</div>
+					</div>
+
+					<div class="filter-group">
 						<h3 class="filter-group-title">Status</h3>
 						<div class="tag-grid">
 							<button
@@ -263,6 +284,7 @@
 					onclick={() => {
 						selectedTags = [];
 						selectedStatuses = [];
+						sortOrder = 'newest';
 					}}
 				>
 					Reset Filter


### PR DESCRIPTION
## Summary

- add newest/oldest sorting controls on the list page
- make newest the default list order
- mark the Name.com domain promo as expired because the code no longer works
- remove maintainer direct-token instructions from the public README
- point the README data reference to bansos.json
- replace the old credit text with a GitHub contributor avatar

## Validation

- npm run check

## Cloudflare

- intended to test Git-connected Cloudflare Pages preview deployment