### PR TITLE
fix: update CLI examples and help command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2913,7 +2913,7 @@
 		},
 		"packages/bansosdev-cli": {
 			"name": "bansosdev",
-			"version": "0.1.0",
+			"version": "0.1.2",
 			"license": "MIT",
 			"bin": {
 				"bansosdev": "bin/bansosdev.mjs"

--- a/packages/bansosdev-cli/README.md
+++ b/packages/bansosdev-cli/README.md
@@ -2,6 +2,12 @@
 
 CLI untuk menambahkan entri bansos ke repo [bansos.dev](https://bansos.dev).
 
+Lihat bantuan CLI:
+
+```bash
+npx bansosdev --help
+```
+
 ## Mode contributor
 
 Default mode adalah `issue`.

--- a/packages/bansosdev-cli/bin/bansosdev.mjs
+++ b/packages/bansosdev-cli/bin/bansosdev.mjs
@@ -212,14 +212,15 @@ async function dispatchWorkflow(args, payload) {
 }
 
 async function main() {
-	const args = parseArgs(process.argv.slice(2));
+	const argv = process.argv.slice(2);
+	const args = parseArgs(argv);
 	if (
 		!args.command ||
 		args.command === 'help' ||
 		args.command === '--help' ||
 		args.command === '-h' ||
 		args.help === 'true' ||
-		args.h === 'true'
+		argv.includes('-h')
 	) {
 		help();
 		return;

--- a/packages/bansosdev-cli/bin/bansosdev.mjs
+++ b/packages/bansosdev-cli/bin/bansosdev.mjs
@@ -213,7 +213,14 @@ async function dispatchWorkflow(args, payload) {
 
 async function main() {
 	const args = parseArgs(process.argv.slice(2));
-	if (!args.command || args.command === 'help' || args.help === 'true') {
+	if (
+		!args.command ||
+		args.command === 'help' ||
+		args.command === '--help' ||
+		args.command === '-h' ||
+		args.help === 'true' ||
+		args.h === 'true'
+	) {
 		help();
 		return;
 	}

--- a/packages/bansosdev-cli/package.json
+++ b/packages/bansosdev-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bansosdev",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "CLI untuk submit dan menambahkan daftar bansos.dev.",
 	"type": "module",
 	"bin": {

--- a/src/routes/contribute/+page.svelte
+++ b/src/routes/contribute/+page.svelte
@@ -2,22 +2,25 @@
 	import { getContributorStats, type ContributorSummary } from '$lib/data/bansos';
 
 	const contributors: ContributorSummary[] = getContributorStats();
-	const singleLineExample = 'npx bansosdev --help';
+	const singleLineExample =
+		'npx bansosdev add --id contoh-bansos --title "Contoh" --provider "Provider" --description "Deskripsi singkat" --benefits "Benefit 1|Benefit 2" --validity-type "uncertain" --validity-desc "Berlaku sampai slot habis" --requirements "Buat akun|Klaim program" --cta-link "https://example.com" --contributor-name "Nama Kamu" --contributor-url "https://example.com" --tags "Cloud,Gratisan" --status active';
 	const multilineExample = [
 		'npx bansosdev add \\',
-		'  --id contoh-bansos \\',
-		'  --title "Contoh Bansos Developer" \\',
-		'  --provider "Provider" \\',
-		'  --description "Deskripsi singkat bansos." \\',
-		'  --benefits "Benefit satu|Benefit dua" \\',
+		'  --id namecom-domain-app \\',
+		'  --title "Promo Domain .DEV & .APP Gratis dari Name.com" \\',
+		'  --provider "Name.com" \\',
+		'  --description "Domain .dev dan .app gratis buat developer yang mau rilis aplikasi tanpa keluar budget domain." \\',
+		'  --benefits "Domain .dev dan .app gratis|Tidak perlu kartu kredit|Limit 1 domain per akun|Promo code DEVWEEK26 sudah tidak aktif" \\',
 		'  --validity-type "uncertain" \\',
-		'  --validity-desc "Berlaku sampai slot habis" \\',
-		'  --requirements "Buat akun|Klaim program" \\',
-		'  --cta-link "https://example.com" \\',
-		'  --contributor-name "Nama Kamu" \\',
-		'  --contributor-url "https://example.com" \\',
-		'  --tags "Cloud,Gratisan" \\',
-		'  --status active'
+		'  --validity-desc "Sudah tidak aktif (promo code tidak bisa digunakan lagi)" \\',
+		'  --requirements "Punya akun Name.com aktif|Pilih domain .dev atau .app yang tersedia|Gunakan promo code pas checkout" \\',
+		'  --promo-code "DEVWEEK26" \\',
+		'  --cta-link "https://www.name.com" \\',
+		'  --contributor-name "Wauputra" \\',
+		'  --contributor-url "https://wau.my.id" \\',
+		'  --tags "Domain,Gratisan,No Credit Card" \\',
+		'  --featured true \\',
+		'  --status expired'
 	].join('\n');
 	let copiedNotice = $state('');
 


### PR DESCRIPTION
## Ringkas
- Update contoh horizontal di halaman kontribusi jadi full parameter tapi isi singkat.
- Update contoh multiline memakai data real dari `namecom-domain-app`.
- Tambahkan support `npx bansosdev --help` dan `-h` di CLI.
- Bump package `bansosdev` ke `0.1.2` untuk publish ulang npm.

## Validasi
- `node packages/bansosdev-cli/bin/bansosdev.mjs --help`
- contoh command horizontal via `--mode json`
- `npm run lint`
- `npm run build`

## Catatan
Setelah merge, package npm perlu dipublish ulang agar `npx bansosdev --help` di user lain tidak lagi memakai versi lama.