### PR TITLE
[codex] add Dahono Labs AI API bansos

### DIFF
--- a/scripts/add-bansos.mjs
+++ b/scripts/add-bansos.mjs
@@ -84,13 +84,9 @@ if (validityDesc) {
 }
 
 const contributorName =
-	mergedArgs['contributor-name'] ||
-	mergedArgs.contributorName ||
-	(mergedArgs.contributor && mergedArgs.contributor.name);
+	mergedArgs['contributor-name'] || mergedArgs.contributorName || mergedArgs.contributor?.name;
 const contributorUrl =
-	mergedArgs['contributor-url'] ||
-	mergedArgs.contributorUrl ||
-	(mergedArgs.contributor && mergedArgs.contributor.url);
+	mergedArgs['contributor-url'] || mergedArgs.contributorUrl || mergedArgs.contributor?.url;
 
 const item = {
 	id: required(mergedArgs, 'id'),

--- a/scripts/add-bansos.mjs
+++ b/scripts/add-bansos.mjs
@@ -83,6 +83,15 @@ if (validityDesc) {
 	validity.description = validityDesc;
 }
 
+const contributorName =
+	mergedArgs['contributor-name'] ||
+	mergedArgs.contributorName ||
+	(mergedArgs.contributor && mergedArgs.contributor.name);
+const contributorUrl =
+	mergedArgs['contributor-url'] ||
+	mergedArgs.contributorUrl ||
+	(mergedArgs.contributor && mergedArgs.contributor.url);
+
 const item = {
 	id: required(mergedArgs, 'id'),
 	title: required(mergedArgs, 'title'),
@@ -98,11 +107,10 @@ const item = {
 		: list(required(mergedArgs, 'requirements')),
 	tips: mergedArgs.tips,
 	contributor:
-		(mergedArgs['contributor-name'] || mergedArgs.contributorName) &&
-		(mergedArgs['contributor-url'] || mergedArgs.contributorUrl)
+		contributorName && contributorUrl
 			? {
-					name: mergedArgs['contributor-name'] || mergedArgs.contributorName,
-					url: mergedArgs['contributor-url'] || mergedArgs.contributorUrl
+					name: contributorName,
+					url: contributorUrl
 				}
 			: undefined,
 	ctaLink: mergedArgs['cta-link'] || required(mergedArgs, 'ctaLink'),
@@ -115,12 +123,7 @@ if (item.benefits.length === 0) throw new Error('--benefits must contain at leas
 if (item.requirements.length === 0)
 	throw new Error('--requirements must contain at least one item');
 if (item.tags.length === 0) throw new Error('--tags must contain at least one item');
-if (
-	((mergedArgs['contributor-name'] || mergedArgs.contributorName) &&
-		!(mergedArgs['contributor-url'] || mergedArgs.contributorUrl)) ||
-	(!(mergedArgs['contributor-name'] || mergedArgs.contributorName) &&
-		(mergedArgs['contributor-url'] || mergedArgs.contributorUrl))
-) {
+if ((contributorName && !contributorUrl) || (!contributorName && contributorUrl)) {
 	throw new Error('Use --contributor-name and --contributor-url together');
 }
 

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -225,22 +225,13 @@
 			"type": "forever",
 			"description": "Berlaku untuk semua pengguna yang mendaftar"
 		},
-		"requirements": [
-			"Daftar akun di Dahono Labs Gateway",
-			"Masuk ke Dashboard dan buat API Key"
-		],
+		"requirements": ["Daftar akun di Dahono Labs Gateway", "Masuk ke Dashboard dan buat API Key"],
 		"contributor": {
 			"name": "Dahono Labs",
 			"url": "https://labs.dahono.com/"
 		},
 		"ctaLink": "https://gateway.dahono.com/",
-		"tags": [
-			"API",
-			"AI",
-			"OpenAI Compatible",
-			"Gratisan",
-			"No Credit Card"
-		],
+		"tags": ["API", "AI", "OpenAI Compatible", "Gratisan", "No Credit Card"],
 		"featured": true,
 		"status": "active"
 	}

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -209,5 +209,39 @@
 		"tags": ["AI Education", "Course", "Gratisan", "Sertifikat", "Referral"],
 		"featured": true,
 		"status": "active"
+	},
+	{
+		"id": "dahono-labs-ai-api",
+		"title": "Akses API AI (OpenAI Compatible) Gratis dari Dahono Labs",
+		"provider": "Dahono Labs",
+		"description": "Dapatkan akses API AI yang 100% kompatibel dengan OpenAI (mendukung Qwen, DeepSeek, Claude, dll) secara gratis untuk developer. Cocok untuk testing dan rilis aplikasi AI tanpa mikir budget API.",
+		"benefits": [
+			"100% OpenAI Compatible API",
+			"Mendukung banyak model flagship (Qwen, DeepSeek, dll)",
+			"Tidak perlu kartu kredit",
+			"Kuota gratis per hari (Tier Free s/d 2 juta TPD)"
+		],
+		"validity": {
+			"type": "forever",
+			"description": "Berlaku untuk semua pengguna yang mendaftar"
+		},
+		"requirements": [
+			"Daftar akun di Dahono Labs Gateway",
+			"Masuk ke Dashboard dan buat API Key"
+		],
+		"contributor": {
+			"name": "Dahono Labs",
+			"url": "https://labs.dahono.com/"
+		},
+		"ctaLink": "https://gateway.dahono.com/",
+		"tags": [
+			"API",
+			"AI",
+			"OpenAI Compatible",
+			"Gratisan",
+			"No Credit Card"
+		],
+		"featured": true,
+		"status": "active"
 	}
 ]


### PR DESCRIPTION
## Summary
- Add Dahono Labs AI API as a new bansos entry from issue #12
- Preserve contributor metadata from issue JSON submissions in `scripts/add-bansos.mjs`

## Notes
- Verified the submitted provider pages expose Dahono Labs and an OpenAI-compatible gateway.
- No local test run in this PR; change is limited to data plus the JSON contributor parser.

Relates to #12