### PR TITLE
[codex] automate bansos issue PR flow

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -1,0 +1,85 @@
+name: Issue to Bansos PR
+
+on:
+  issues:
+    types: [opened, edited, labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  create-pr:
+    if: |
+      contains(github.event.issue.labels.*.name, 'submission') ||
+      startsWith(github.event.issue.title, 'Tambah bansos:')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Extract issue payload
+        id: payload
+        run: node scripts/issue-to-pr.mjs
+        env:
+          BANSOS_PAYLOAD_PATH: .tmp-bansos-issue.json
+
+      - name: Add bansos item
+        run: npm run add:bansos -- --json .tmp-bansos-issue.json
+
+      - name: Build site
+        run: npm run build
+
+      - name: Create pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ITEM_ID: ${{ steps.payload.outputs.id }}
+          ITEM_TITLE: ${{ steps.payload.outputs.title }}
+        run: |
+          set -euo pipefail
+
+          branch="bansos/issue-${ISSUE_NUMBER}-${ITEM_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add src/lib/data/bansos.json
+          git commit -m "feat: add ${ITEM_TITLE}"
+          git push --force origin "$branch"
+
+          existing_pr="$(gh pr list --head "$branch" --json url --jq '.[0].url')"
+          if [ -n "$existing_pr" ]; then
+            echo "url=$existing_pr" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_url="$(
+            gh pr create \
+              --title "Tambah bansos: ${ITEM_TITLE}" \
+              --body "Auto-generated from #${ISSUE_NUMBER}.
+
+## Summary
+- Add ${ITEM_TITLE} to the bansos list.
+- Source payload comes from the contributor issue.
+
+Closes #${ISSUE_NUMBER}" \
+              --base main \
+              --head "$branch"
+          )"
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "Terima kasih sudah submit bansos ini! PR otomatis sudah dibuat di ${PR_URL}."

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Ada dua cara:
 
 ### 1) Via CLI (disarankan untuk kontribusi umum)
 
-Jalankan ini, nanti CLI akan mengembalikan URL issue GitHub yang siap dikirim:
+Jalankan ini, nanti CLI akan mengembalikan URL issue GitHub yang siap dikirim.
+Kalau payload valid, GitHub Actions akan membuat Pull Request otomatis dari issue tersebut:
 
 ```bash
 npx bansosdev add \
@@ -39,6 +40,7 @@ npx bansosdev add \
   --validity-type fixed \
   --validity-date 2026-06-30 \
   --validity-desc "Berlaku khusus pelajar" \
+  --published-at 2026-06-13 \
   --requirements "Buat akun|Klaim program" \
   --cta-link "https://example.com" \
   --contributor-name "Nama Kamu" \
@@ -54,6 +56,7 @@ Agar format UI seragam, input masa berlaku (validity) kini menggunakan format te
 - `--validity-type` **(Wajib)**: Pilih salah satu dari `fixed` (ada batas waktu), `uncertain` (tidak menentu), atau `forever` (selamanya).
 - `--validity-date` **(Wajib jika type=fixed)**: Tanggal kadaluarsa promo dalam format `YYYY-MM-DD` (contoh: `2026-06-30`). Sistem akan otomatis menandai bansos sebagai `expired` jika melewati tanggal ini.
 - `--validity-desc` _(Opsional)_: Tambahan catatan khusus terkait masa berlaku (contoh: "Selama kuota masih ada"). Teks ini akan muncul sebagai _tooltip_ saat label masa berlaku di-hover.
+- `--published-at` _(Opsional)_: Tanggal publikasi entry dalam format `YYYY-MM-DD`. Jika kosong, CLI/script akan mengisi tanggal hari ini.
 
 ### Cek payload
 
@@ -96,7 +99,7 @@ Detail lengkap CLI lihat [docs/bansosdev-cli.md](docs/bansosdev-cli.md).
 
 ## Kontribusi
 
-- Kirim data lewat CLI (cara utama) lalu follow up PR dengan issue dari URL yang muncul.
+- Kirim data lewat CLI (cara utama), buka issue dari URL yang muncul, lalu tunggu PR otomatis dari bot.
 - Jika lebih nyaman, tambahkan melalui branch + PR manual.
 - Lihat panduan kontribusi lengkap di [CONTRIBUTING](https://github.com/wauputr4/bansos?tab=contributing-ov-file).
 

--- a/docs/bansosdev-cli.md
+++ b/docs/bansosdev-cli.md
@@ -5,7 +5,7 @@
 ## Cara kerja singkat
 
 - Mode default: `issue`.
-  CLI menghasilkan URL GitHub Issue dengan payload JSON dalam format yang siap digunakan maintainer.
+  CLI menghasilkan URL GitHub Issue dengan payload JSON. Issue yang valid akan dibuatkan Pull Request otomatis oleh GitHub Actions.
 - `--mode direct`: maintainer trigger `workflow_dispatch` ke repo.
 - `--mode json`: cetak payload JSON saja (untuk validasi).
 
@@ -20,6 +20,7 @@ npx bansosdev add \
   --benefits "Benefit satu|Benefit dua" \
   --validity-type "uncertain" \
   --validity-desc "Berlaku sampai slot habis" \
+  --published-at "2026-06-13" \
   --requirements "Buat akun|Klaim program" \
   --cta-link "https://example.com" \
   --contributor-name "Nama Kamu" \

--- a/packages/bansosdev-cli/README.md
+++ b/packages/bansosdev-cli/README.md
@@ -11,6 +11,7 @@ npx bansosdev --help
 ## Mode contributor
 
 Default mode adalah `issue`.
+Issue yang valid akan diproses GitHub Actions menjadi Pull Request otomatis.
 
 ```bash
 npx bansosdev add \
@@ -22,6 +23,7 @@ npx bansosdev add \
   --validity-type fixed \
   --validity-date 2026-06-30 \
   --validity-desc "Berlaku khusus akun baru" \
+  --published-at 2026-06-13 \
   --requirements "Daftar akun|Klaim program" \
   --cta-link "https://example.com" \
   --contributor-name "Nama Kamu" \
@@ -43,7 +45,8 @@ Contoh input `forever` (tanpa date):
 npx bansosdev add ... --validity-type forever --validity-desc "Berlaku selamanya"
 ```
 
-Mode ini akan mencetak URL issue GitHub dengan payload JSON.
+Mode ini akan mencetak URL issue GitHub dengan payload JSON. Setelah issue dibuat,
+workflow repo akan mencoba membuat Pull Request otomatis dari payload tersebut.
 
 ## Maintainer mode
 

--- a/packages/bansosdev-cli/bin/bansosdev.mjs
+++ b/packages/bansosdev-cli/bin/bansosdev.mjs
@@ -30,7 +30,7 @@ Usage:
 
 Modes:
   --mode direct   Trigger trusted GitHub Action commit (needs token)
-  --mode issue    Print a prefilled GitHub issue URL for public submission
+  --mode issue    Print a prefilled GitHub issue URL; valid issues become PRs automatically
   --mode json     Print validated JSON payload only
 
 Required:
@@ -47,6 +47,7 @@ Required:
 Optional:
   --validity-date YYYY-MM-DD (required if type is fixed)
   --validity-desc "Description"
+  --published-at YYYY-MM-DD
   --promo-code CODE
   --tips "Tips singkat"
   --contributor-name "Nama"
@@ -109,6 +110,10 @@ function payloadFromArgs(args) {
 	if (args['validity-desc']) {
 		validity.description = args['validity-desc'];
 	}
+	const publishedAt = args['published-at'] || new Date().toISOString().slice(0, 10);
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(publishedAt)) {
+		throw new Error('--published-at must be YYYY-MM-DD');
+	}
 
 	const payload = {
 		id: required(args, 'id'),
@@ -120,6 +125,7 @@ function payloadFromArgs(args) {
 		validity: validity,
 		requirements: list(required(args, 'requirements')),
 		tips: args.tips,
+		publishedAt,
 		contributor:
 			args['contributor-name'] && args['contributor-url']
 				? {

--- a/packages/bansosdev-cli/bin/bansosdev.mjs
+++ b/packages/bansosdev-cli/bin/bansosdev.mjs
@@ -86,6 +86,19 @@ function validateUrl(value, key) {
 	}
 }
 
+function isValidCalendarDate(value) {
+\tif (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+\t\treturn false;
+\t}
+\tconst [year, month, day] = value.split('-').map(Number);
+\tconst parsedDate = new Date(year, month - 1, day);
+\treturn (
+\t\tparsedDate.getFullYear() === year &&
+\t\tparsedDate.getMonth() === month - 1 &&
+\t\tparsedDate.getDate() === day
+\t);
+}
+
 function payloadFromArgs(args) {
 	const validityType = required(args, 'validity-type');
 	if (!['fixed', 'uncertain', 'forever'].includes(validityType)) {
@@ -111,8 +124,8 @@ function payloadFromArgs(args) {
 		validity.description = args['validity-desc'];
 	}
 	const publishedAt = args['published-at'] || new Date().toISOString().slice(0, 10);
-	if (!/^\d{4}-\d{2}-\d{2}$/.test(publishedAt)) {
-		throw new Error('--published-at must be YYYY-MM-DD');
+	if (!isValidCalendarDate(publishedAt)) {
+		throw new Error('--published-at must be a valid YYYY-MM-DD date');
 	}
 
 	const payload = {

--- a/scripts/add-bansos.mjs
+++ b/scripts/add-bansos.mjs
@@ -87,6 +87,14 @@ const contributorName =
 	mergedArgs['contributor-name'] || mergedArgs.contributorName || mergedArgs.contributor?.name;
 const contributorUrl =
 	mergedArgs['contributor-url'] || mergedArgs.contributorUrl || mergedArgs.contributor?.url;
+const publishedAt =
+	mergedArgs['published-at'] ||
+	mergedArgs.publishedAt ||
+	new Date().toISOString().slice(0, 10);
+
+if (!/^\d{4}-\d{2}-\d{2}$/.test(publishedAt)) {
+	throw new Error('publishedAt must be YYYY-MM-DD');
+}
 
 const item = {
 	id: required(mergedArgs, 'id'),
@@ -102,6 +110,7 @@ const item = {
 		? mergedArgs.requirements
 		: list(required(mergedArgs, 'requirements')),
 	tips: mergedArgs.tips,
+	publishedAt,
 	contributor:
 		contributorName && contributorUrl
 			? {

--- a/scripts/add-bansos.mjs
+++ b/scripts/add-bansos.mjs
@@ -5,6 +5,19 @@ import { dirname, join } from 'node:path';
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const dataPath = join(root, 'src/lib/data/bansos.json');
 
+function isValidCalendarDate(value) {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		return false;
+	}
+	const [year, month, day] = value.split('-').map(Number);
+	const parsedDate = new Date(year, month - 1, day);
+	return (
+		parsedDate.getFullYear() === year &&
+		parsedDate.getMonth() === month - 1 &&
+		parsedDate.getDate() === day
+	);
+}
+
 function parseArgs(argv) {
 	const args = {};
 	for (let index = 0; index < argv.length; index += 1) {
@@ -92,8 +105,8 @@ const publishedAt =
 	mergedArgs.publishedAt ||
 	new Date().toISOString().slice(0, 10);
 
-if (!/^\d{4}-\d{2}-\d{2}$/.test(publishedAt)) {
-	throw new Error('publishedAt must be YYYY-MM-DD');
+if (!isValidCalendarDate(publishedAt)) {
+	throw new Error('publishedAt must be a valid YYYY-MM-DD date');
 }
 
 const item = {

--- a/scripts/issue-to-pr.mjs
+++ b/scripts/issue-to-pr.mjs
@@ -1,0 +1,40 @@
+import { readFileSync, writeFileSync, appendFileSync } from 'node:fs';
+
+const eventPath = process.env.GITHUB_EVENT_PATH;
+const outputPath = process.env.BANSOS_PAYLOAD_PATH || '.tmp-bansos-issue.json';
+const githubOutput = process.env.GITHUB_OUTPUT;
+
+if (!eventPath) {
+	throw new Error('GITHUB_EVENT_PATH is required');
+}
+
+const event = JSON.parse(readFileSync(eventPath, 'utf8'));
+const issue = event.issue;
+
+if (!issue) {
+	throw new Error('This workflow must be triggered by a GitHub issue event');
+}
+
+const body = issue.body || '';
+const jsonBlock = body.match(/```json\s*([\s\S]*?)```/i);
+
+if (!jsonBlock) {
+	throw new Error('Issue body must contain a fenced ```json payload');
+}
+
+const payload = JSON.parse(jsonBlock[1]);
+
+if (!payload.id || !payload.title) {
+	throw new Error('Issue JSON payload must include id and title');
+}
+
+if (!payload.publishedAt) {
+	payload.publishedAt = new Date().toISOString().slice(0, 10);
+}
+
+writeFileSync(outputPath, JSON.stringify(payload, null, 2) + '\n');
+
+if (githubOutput) {
+	appendFileSync(githubOutput, `id=${payload.id}\n`);
+	appendFileSync(githubOutput, `title=${payload.title.replace(/\n/g, ' ')}\n`);
+}

--- a/scripts/issue-to-pr.mjs
+++ b/scripts/issue-to-pr.mjs
@@ -4,6 +4,19 @@ const eventPath = process.env.GITHUB_EVENT_PATH;
 const outputPath = process.env.BANSOS_PAYLOAD_PATH || '.tmp-bansos-issue.json';
 const githubOutput = process.env.GITHUB_OUTPUT;
 
+function isValidCalendarDate(value) {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+		return false;
+	}
+	const [year, month, day] = value.split('-').map(Number);
+	const parsedDate = new Date(year, month - 1, day);
+	return (
+		parsedDate.getFullYear() === year &&
+		parsedDate.getMonth() === month - 1 &&
+		parsedDate.getDate() === day
+	);
+}
+
 if (!eventPath) {
 	throw new Error('GITHUB_EVENT_PATH is required');
 }
@@ -28,13 +41,19 @@ if (!payload.id || !payload.title) {
 	throw new Error('Issue JSON payload must include id and title');
 }
 
+if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(payload.id)) {
+	throw new Error('Issue JSON payload id must be kebab-case lowercase, e.g. tokenrouter-credits');
+}
+
 if (!payload.publishedAt) {
 	payload.publishedAt = new Date().toISOString().slice(0, 10);
+} else if (!isValidCalendarDate(payload.publishedAt)) {
+	throw new Error('Issue JSON payload publishedAt must be a valid date in YYYY-MM-DD format');
 }
 
 writeFileSync(outputPath, JSON.stringify(payload, null, 2) + '\n');
 
 if (githubOutput) {
 	appendFileSync(githubOutput, `id=${payload.id}\n`);
-	appendFileSync(githubOutput, `title=${payload.title.replace(/\n/g, ' ')}\n`);
+	appendFileSync(githubOutput, `title=${payload.title.replace(/[\r\n]/g, ' ')}\n`);
 }

--- a/src/lib/components/SiteShell.svelte
+++ b/src/lib/components/SiteShell.svelte
@@ -9,7 +9,11 @@
 		{ href: '/list', label: 'Bansos', icon: 'fa-solid fa-list' },
 		{ href: '/contribute', label: 'Kontribusi', icon: 'fa-solid fa-plus' },
 		{ href: '/about', label: 'Tentang', icon: 'fa-solid fa-circle-question' }
-	];
+	] as const;
+
+	function isActivePath(pathname: string, href: string) {
+		return pathname === href || (href !== '/' && pathname.startsWith(`${href}/`));
+	}
 </script>
 
 <svelte:head>
@@ -24,12 +28,7 @@
 				{#each navItems as item (item.href)}
 					<a
 						href={resolve(item.href)}
-						class={item.href !== '/' &&
-						($page.url.pathname === item.href || $page.url.pathname.startsWith(item.href + '/'))
-							? 'active'
-							: $page.url.pathname === item.href
-								? 'active'
-								: ''}>{item.label}</a
+						class={isActivePath($page.url.pathname, item.href) ? 'active' : ''}>{item.label}</a
 					>
 				{/each}
 			</div>
@@ -57,10 +56,7 @@
 		{#each navItems as item (item.href)}
 			<a
 				href={resolve(item.href)}
-				class={$page.url.pathname === item.href ||
-				(item.href !== '/' && $page.url.pathname.startsWith(item.href))
-					? 'active'
-					: ''}
+				class={isActivePath($page.url.pathname, item.href) ? 'active' : ''}
 			>
 				<span aria-hidden="true"><i class={item.icon}></i></span>
 				{item.label}

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -21,6 +21,7 @@
 			"Gunakan promo code pas checkout"
 		],
 		"tips": "Promo ini sudah tidak aktif dan promo code tidak bisa dipakai lagi. Tetap disimpan sebagai arsip bansos biar developer lain gak buang waktu nyobain kode yang sudah wafat.",
+		"publishedAt": "2026-06-11",
 		"contributor": {
 			"name": "Wauputra",
 			"url": "https://wau.my.id"
@@ -55,6 +56,7 @@
 			"Pastikan kamu cek rules resmi karena approval dan voucher bisa punya ketentuan tambahan"
 		],
 		"tips": "Kalau modal masih tipis, mulai dari $1 dulu. Kejar sebelum 17 Juni 2026 biar gak mepet dan jangan lupa baca campaign rules.",
+		"publishedAt": "2026-06-11",
 		"contributor": {
 			"name": "!mika",
 			"url": "https://www.mikacend.xyz/"
@@ -87,6 +89,7 @@
 			"Cek lagi ketentuan resmi karena ini data agregator, bukan verifier"
 		],
 		"tips": "Gas buat prototype dulu, tapi jangan taruh API key di frontend. Developer jelata juga wajib punya secret management.",
+		"publishedAt": "2026-06-12",
 		"contributor": {
 			"name": "TokenGratis.id",
 			"url": "https://www.tokengratis.id/provider/deepseek"
@@ -120,6 +123,7 @@
 			"Isi data sesuai kebutuhan API docs",
 			"Tambahkan billing jika butuh lanjut setelah kuota habis"
 		],
+		"publishedAt": "2026-06-12",
 		"contributor": {
 			"name": "wauputra",
 			"url": "https://wau.my.id/"
@@ -140,6 +144,7 @@
 			"description": "Selamanya"
 		},
 		"requirements": ["Daftar akun di Kimchi.dev", "Verifikasi alamat email"],
+		"publishedAt": "2026-06-12",
 		"contributor": {
 			"name": "DevERS",
 			"url": "https://renzlab.my.id"
@@ -173,6 +178,7 @@
 			"Manfaatkan free credit dan bandingkan pricing sebelum top-up"
 		],
 		"tips": "Cek dashboard secara berkala karena free credit dan promo bisa berubah. Jangan expose API key di frontend; pakai env/server-side proxy biar aman.",
+		"publishedAt": "2026-06-13",
 		"contributor": {
 			"name": "Pena Digital",
 			"url": "https://penadigital.tech/"
@@ -201,6 +207,7 @@
 			"Bawa tautan referal guru saat daftar jika diminta sistem",
 			"Bisa dapat bonus pulsa 50.000 setelah menyelesaikan semua misi (informasi dari peserta)"
 		],
+		"publishedAt": "2026-06-13",
 		"contributor": {
 			"name": "Wildan",
 			"url": "https://kelas.bisnix.com/"
@@ -226,6 +233,7 @@
 			"description": "Berlaku untuk semua pengguna yang mendaftar"
 		},
 		"requirements": ["Daftar akun di Dahono Labs Gateway", "Masuk ke Dashboard dan buat API Key"],
+		"publishedAt": "2026-06-13",
 		"contributor": {
 			"name": "Dahono Labs",
 			"url": "https://labs.dahono.com/"

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -32,6 +32,68 @@
 		"status": "expired"
 	},
 	{
+		"id": "namecheap-vps-hosting",
+		"title": "Namecheap VPS Hosting dengan Harga Mulai 3.88$/Bulan",
+		"provider": "Namecheap",
+		"description": "Paket VPS dari Namecheap dengan harga murah, plan sesuai kebutuhan, dan opsi free trial. Cocok buat yang butuh kontrol server sendiri tanpa ribet.",
+		"benefits": [
+			"Plan VPS mulai dari Spark sampai Hypernova",
+			"Mulai dari 1 CPU, RAM 1GB, SSD 20GB, bandwidth 1000GB",
+			"Pilihan manajemen server serta root access dan kontrol panel",
+			"Tersedia free trial sebelum upgrade ke berlangganan"
+		],
+		"validity": {
+			"type": "uncertain",
+			"description": "Promo dan harga ditampilkan sesuai periode di halaman resmi"
+		},
+		"requirements": [
+			"Buat/masuk akun Namecheap",
+			"Pilih plan VPS sesuai kebutuhan dan sumber daya yang kamu butuhkan",
+			"Lanjutkan checkout dan pilih durasi billing"
+		],
+		"publishedAt": "2026-06-13",
+		"contributor": {
+			"name": "wau",
+			"url": "https://wau.my.id"
+		},
+		"ctaLink": "https://www.namecheap.com/hosting/vps/",
+		"tags": ["VPS", "Hosting", "Server", "Gratis Trial"],
+		"featured": false,
+		"status": "active"
+	},
+	{
+		"id": "idwebhost-domain-gratis-1tahun",
+		"title": "Domain Gratis 1 Tahun di IDwebhost (pakai kupon)",
+		"provider": "IDwebhost",
+		"description": "Klaim domain gratis 1 tahun buat bikin web cepat, cukup pakai kupon saat checkout dan pilih ekstensi yang didukung.",
+		"benefits": [
+			"Domain gratis 1 tahun untuk yang ambil paket sesuai campaign",
+			"Mendukung klaim domain .my.id, .web.id, atau .biz.id",
+			"Kupon `mAts2Mey` jadi jalan masuk utama untuk promo",
+			"Tidak perlu tambahan paket hosting, SSL, maupun email hosting"
+		],
+		"validity": {
+			"type": "uncertain",
+			"description": "Promo dan validitas kupon bisa berubah sesuai campaign saat ini"
+		},
+		"requirements": [
+			"Punya akun di IDwebhost",
+			"Pilih domain gratis yang diinginkan",
+			"Masukkan kupon `mAts2Mey`",
+			"Saat checkout, jangan centang hosting, SSL, dan email hosting sesuai instruksi"
+		],
+		"tips": "Masukkan domain yang diinginkan dulu, lalu isi kupon dan pastikan item hosting/SSL/email hosting tidak dipilih.",
+		"publishedAt": "2026-06-13",
+		"contributor": {
+			"name": "ᴀᴢɪᴢ ʙᴜᴅɪ ꜱᴀᴛʀɪᴏ",
+			"url": "https://lynk.id/azizbudisatrio?utm_source=threads&utm_medium=social&utm_content=link_in_bio"
+		},
+		"ctaLink": "https://idwebhost.com/",
+		"tags": ["Domain", "Promo", "Kupon", "Gratisan"],
+		"featured": false,
+		"status": "active"
+	},
+	{
 		"id": "tokenrouter-model-gateway",
 		"title": "Free Credits TokenRouter buat Jajan Model AI",
 		"provider": "TokenRouter",

--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -15,6 +15,7 @@ export interface BansosItem {
 	};
 	requirements: string[];
 	tips?: string;
+	publishedAt?: string;
 	contributor?: {
 		name: string;
 		url: string;
@@ -66,12 +67,51 @@ export const bansosList: BansosItem[] = (bansosData as BansosItem[]).map((item) 
 	addTrackedCtaLink(item)
 );
 
-export const latestBansos = (limit = 3) => bansosList.slice(-limit).reverse();
-export const featuredBansos = (limit = 3) =>
-	bansosList
+function itemDateValue(item: BansosItem, fallbackIndex: number) {
+	if (!item.publishedAt) return fallbackIndex;
+	const timestamp = Date.parse(`${item.publishedAt}T00:00:00.000Z`);
+	return Number.isNaN(timestamp) ? fallbackIndex : timestamp;
+}
+
+export function sortBansosByNewest(items: BansosItem[] = bansosList) {
+	return items
+		.map((item, index) => ({ item, index }))
+		.sort((a, b) => {
+			const dateDiff = itemDateValue(b.item, b.index) - itemDateValue(a.item, a.index);
+			if (dateDiff !== 0) return dateDiff;
+			return b.index - a.index;
+		})
+		.map(({ item }) => item);
+}
+
+export const latestBansos = (limit = 3, items: BansosItem[] = bansosList) =>
+	sortBansosByNewest(items).slice(0, limit);
+
+export const featuredBansos = (limit = 3, items: BansosItem[] = bansosList) =>
+	sortBansosByNewest(items)
 		.filter((i) => i.featured && i.status !== 'expired')
-		.slice(-limit)
-		.reverse();
+		.slice(0, limit);
+
+export function recommendedBansosFor(
+	currentItem: BansosItem,
+	items: BansosItem[] = bansosList,
+	limit = 3
+) {
+	const currentTags = new Set(currentItem.tags);
+
+	return sortBansosByNewest(items)
+		.filter((entry) => entry.id !== currentItem.id)
+		.filter((entry) => entry.status === 'active')
+		.map((entry) => ({
+			entry,
+			score:
+				entry.tags.filter((tag) => currentTags.has(tag)).length * 10 +
+				(entry.featured ? 2 : 0)
+		}))
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit)
+		.map(({ entry }) => entry);
+}
 
 export const allBansosTags = Array.from(new Set(bansosList.flatMap((item) => item.tags))).sort(
 	(a, b) => a.localeCompare(b)

--- a/src/routes/contribute/+page.svelte
+++ b/src/routes/contribute/+page.svelte
@@ -15,6 +15,7 @@
 		'  --validity-desc "Sudah tidak aktif (promo code tidak bisa digunakan lagi)" \\',
 		'  --requirements "Punya akun Name.com aktif|Pilih domain .dev atau .app yang tersedia|Gunakan promo code pas checkout" \\',
 		'  --promo-code "DEVWEEK26" \\',
+		'  --published-at "2026-06-11" \\',
 		'  --cta-link "https://www.name.com" \\',
 		'  --contributor-name "Wauputra" \\',
 		'  --contributor-url "https://wau.my.id" \\',
@@ -50,8 +51,9 @@
 		<p class="eyebrow">Kontribusi</p>
 		<h1 class="text-gradient">Punya info bansos? Jangan dinikmati sendirian.</h1>
 		<p>
-			Info baru bisa ditambahkan lewat Pull Request. Isi minimalnya: nama program, provider,
-			benefit, syarat klaim, masa berlaku, link official, tag, dan nama kontributor.
+			Info baru bisa ditambahkan lewat CLI. Kamu submit issue dari hasil command, lalu bot akan
+			bikin Pull Request otomatis kalau payload JSON valid. Isi minimalnya: nama program,
+			provider, benefit, syarat klaim, masa berlaku, link official, tag, dan nama kontributor.
 		</p>
 
 		<div class="command-box">

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { resolve } from '$app/paths';
 	import FloatingEmoji from '$lib/components/FloatingEmoji.svelte';
 	import BansosCard from '$lib/components/BansosCard.svelte';
+	import { recommendedBansosFor } from '$lib/data/bansos';
 	import { bansosState, initBansosStore, fetchLatestBansos } from '$lib/stores/bansos.svelte';
 	import { onMount } from 'svelte';
 
@@ -96,11 +97,7 @@
 
 	const recommendedBansos = $derived.by(() => {
 		if (!item) return [];
-		return bansosState.data
-			.filter((entry) => entry.id !== item.id)
-			.filter((entry) => entry.status === 'active')
-			.slice(-3)
-			.reverse();
+		return recommendedBansosFor(item, bansosState.data, 3);
 	});
 </script>
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions automation that turns valid bansos submission issues into pull requests.
- Add `publishedAt` support across the CLI, add script, and existing bansos data.
- Standardize latest and recommendation selection through shared data helpers.
- Fix typed route handling in the site shell nav so Svelte check passes.

## Validation
- npm run check
- npm run build