### PR TITLE
cleanup: normalize Namecheap contributor name

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -53,7 +53,7 @@
 		],
 		"publishedAt": "2026-06-13",
 		"contributor": {
-			"name": "wau",
+			"name": "wauputra",
 			"url": "https://wau.my.id"
 		},
 		"ctaLink": "https://www.namecheap.com/hosting/vps/",


### PR DESCRIPTION
## Changes\n- Fix contributor display for Namecheap VPS entry to use `wauputra` (was `wau`) for consistency with contributor identity.\n\n## Notes\n- This is a cleanup PR for contributor metadata accuracy after prior contributor cleanup.