### PR TITLE
[codex] Add white mode and polish header branding

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -76,18 +76,22 @@
 
 	@media (prefers-color-scheme: light) {
 		:root {
+			color-scheme: light;
 			--bg-primary: #f8fafc;
 			--bg-secondary: #ffffff;
 			--text-primary: #0f172a;
 			--text-secondary: #475569;
-			--text-muted: #94a3b8;
-
+			--text-muted: #64748b;
 			--color-accent: #059669;
 			--color-accent-glow: rgba(5, 150, 105, 0.1);
-			--border-color: rgba(0, 0, 0, 0.08);
-			--glass-bg: rgba(255, 255, 255, 0.75);
-			--glass-border: rgba(0, 0, 0, 0.06);
-			--glass-shadow: rgba(15, 23, 42, 0.05);
+			--color-success: #059669;
+			--color-success-glow: rgba(5, 150, 105, 0.12);
+			--color-warning: #d97706;
+			--color-warning-glow: rgba(217, 119, 6, 0.14);
+			--border-color: rgba(15, 23, 42, 0.1);
+			--glass-bg: rgba(255, 255, 255, 0.78);
+			--glass-border: rgba(15, 23, 42, 0.08);
+			--glass-shadow: rgba(15, 23, 42, 0.08);
 		}
 	}
 

--- a/src/app.css
+++ b/src/app.css
@@ -253,6 +253,13 @@
 		background-clip: text;
 	}
 
+	:root[data-theme='light'] .text-gradient {
+		background: linear-gradient(135deg, #059669 0%, #047857 52%, #0f3f35 100%);
+		-webkit-background-clip: text;
+		-webkit-text-fill-color: transparent;
+		background-clip: text;
+	}
+
 	.text-balance {
 		text-wrap: balance;
 	}

--- a/src/app.css
+++ b/src/app.css
@@ -74,27 +74,6 @@
 		--glass-shadow: rgba(0, 0, 0, 0.3);
 	}
 
-	@media (prefers-color-scheme: light) {
-		:root {
-			color-scheme: light;
-			--bg-primary: #f8fafc;
-			--bg-secondary: #ffffff;
-			--text-primary: #0f172a;
-			--text-secondary: #475569;
-			--text-muted: #64748b;
-			--color-accent: #059669;
-			--color-accent-glow: rgba(5, 150, 105, 0.1);
-			--color-success: #059669;
-			--color-success-glow: rgba(5, 150, 105, 0.12);
-			--color-warning: #d97706;
-			--color-warning-glow: rgba(217, 119, 6, 0.14);
-			--border-color: rgba(15, 23, 42, 0.1);
-			--glass-bg: rgba(255, 255, 255, 0.78);
-			--glass-border: rgba(15, 23, 42, 0.08);
-			--glass-shadow: rgba(15, 23, 42, 0.08);
-		}
-	}
-
 	:root[data-theme='light'] {
 		color-scheme: light;
 		--bg-primary: #f8fafc;
@@ -112,6 +91,27 @@
 		--glass-bg: rgba(255, 255, 255, 0.78);
 		--glass-border: rgba(15, 23, 42, 0.08);
 		--glass-shadow: rgba(15, 23, 42, 0.08);
+	}
+
+	@media (prefers-color-scheme: light) {
+		:root:not([data-theme]) {
+			color-scheme: light;
+			--bg-primary: #f8fafc;
+			--bg-secondary: #ffffff;
+			--text-primary: #0f172a;
+			--text-secondary: #475569;
+			--text-muted: #64748b;
+			--color-accent: #059669;
+			--color-accent-glow: rgba(5, 150, 105, 0.1);
+			--color-success: #059669;
+			--color-success-glow: rgba(5, 150, 105, 0.12);
+			--color-warning: #d97706;
+			--color-warning-glow: rgba(217, 119, 6, 0.14);
+			--border-color: rgba(15, 23, 42, 0.1);
+			--glass-bg: rgba(255, 255, 255, 0.78);
+			--glass-border: rgba(15, 23, 42, 0.08);
+			--glass-shadow: rgba(15, 23, 42, 0.08);
+		}
 	}
 
 	body {

--- a/src/app.css
+++ b/src/app.css
@@ -55,6 +55,25 @@
 		scrollbar-width: thin;
 	}
 
+	:root[data-theme='dark'] {
+		color-scheme: dark;
+		--bg-primary: #090a0f;
+		--bg-secondary: #121420;
+		--text-primary: #f8fafc;
+		--text-secondary: #94a3b8;
+		--text-muted: #64748b;
+		--color-accent: #10b981;
+		--color-accent-glow: rgba(16, 185, 129, 0.15);
+		--color-success: #10b981;
+		--color-success-glow: rgba(16, 185, 129, 0.15);
+		--color-warning: #f59e0b;
+		--color-warning-glow: rgba(245, 158, 11, 0.15);
+		--border-color: rgba(255, 255, 255, 0.08);
+		--glass-bg: rgba(18, 20, 32, 0.7);
+		--glass-border: rgba(255, 255, 255, 0.08);
+		--glass-shadow: rgba(0, 0, 0, 0.3);
+	}
+
 	@media (prefers-color-scheme: light) {
 		:root {
 			--bg-primary: #f8fafc;
@@ -70,6 +89,25 @@
 			--glass-border: rgba(0, 0, 0, 0.06);
 			--glass-shadow: rgba(15, 23, 42, 0.05);
 		}
+	}
+
+	:root[data-theme='light'] {
+		color-scheme: light;
+		--bg-primary: #f8fafc;
+		--bg-secondary: #ffffff;
+		--text-primary: #0f172a;
+		--text-secondary: #475569;
+		--text-muted: #64748b;
+		--color-accent: #059669;
+		--color-accent-glow: rgba(5, 150, 105, 0.1);
+		--color-success: #059669;
+		--color-success-glow: rgba(5, 150, 105, 0.12);
+		--color-warning: #d97706;
+		--color-warning-glow: rgba(217, 119, 6, 0.14);
+		--border-color: rgba(15, 23, 42, 0.1);
+		--glass-bg: rgba(255, 255, 255, 0.78);
+		--glass-border: rgba(15, 23, 42, 0.08);
+		--glass-shadow: rgba(15, 23, 42, 0.08);
 	}
 
 	body {
@@ -180,7 +218,7 @@
 	}
 
 	.btn-secondary:hover {
-		background-color: rgba(255, 255, 255, 0.05);
+		background-color: color-mix(in srgb, var(--text-primary) 5%, transparent);
 		border-color: var(--text-secondary);
 	}
 }

--- a/src/lib/components/SiteShell.svelte
+++ b/src/lib/components/SiteShell.svelte
@@ -19,30 +19,25 @@
 		return pathname === href || (href !== '/' && pathname.startsWith(`${href}/`));
 	}
 
-	function applyTheme(nextTheme: ThemeMode) {
-		document.documentElement.dataset.theme = nextTheme;
-		document
-			.querySelector('meta[name="theme-color"]')
-			?.setAttribute('content', nextTheme === 'light' ? '#f8fafc' : '#090a0f');
-	}
+	$effect(() => {
+		document.documentElement.dataset.theme = theme;
+	});
 
 	onMount(() => {
 		const storedTheme = localStorage.getItem(THEME_KEY);
 		const systemTheme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
 		const initialTheme = storedTheme === 'light' || storedTheme === 'dark' ? storedTheme : systemTheme;
 		theme = initialTheme;
-		applyTheme(initialTheme);
 	});
 
 	function toggleTheme() {
 		theme = theme === 'light' ? 'dark' : 'light';
-		applyTheme(theme);
 		localStorage.setItem(THEME_KEY, theme);
 	}
 </script>
 
 <svelte:head>
-	<meta name="theme-color" content="#090a0f" />
+	<meta name="theme-color" content={theme === 'light' ? '#f8fafc' : '#090a0f'} />
 </svelte:head>
 
 <div class="site-shell">
@@ -61,7 +56,7 @@
 				type="button"
 				class="theme-toggle"
 				onclick={toggleTheme}
-				aria-label={theme === 'light' ? 'Aktifkan dark mode' : 'Aktifkan white mode'}
+				aria-label={theme === 'light' ? 'Aktifkan mode gelap' : 'Aktifkan mode terang'}
 			>
 				<i class={theme === 'light' ? 'fa-solid fa-moon' : 'fa-solid fa-sun'} aria-hidden="true"
 				></i>

--- a/src/lib/components/SiteShell.svelte
+++ b/src/lib/components/SiteShell.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import GithubBadge from './GithubBadge.svelte';
 	import { page } from '$app/stores';
+	import { onMount } from 'svelte';
 	let { children } = $props();
+	type ThemeMode = 'dark' | 'light';
+
+	const THEME_KEY = 'bansos-theme';
+	let theme: ThemeMode = $state('dark');
 
 	const navItems = [
 		{ href: '/', label: 'Beranda', icon: 'fa-solid fa-house' },
@@ -14,6 +18,27 @@
 	function isActivePath(pathname: string, href: string) {
 		return pathname === href || (href !== '/' && pathname.startsWith(`${href}/`));
 	}
+
+	function applyTheme(nextTheme: ThemeMode) {
+		document.documentElement.dataset.theme = nextTheme;
+		document
+			.querySelector('meta[name="theme-color"]')
+			?.setAttribute('content', nextTheme === 'light' ? '#f8fafc' : '#090a0f');
+	}
+
+	onMount(() => {
+		const storedTheme = localStorage.getItem(THEME_KEY);
+		const systemTheme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+		const initialTheme = storedTheme === 'light' || storedTheme === 'dark' ? storedTheme : systemTheme;
+		theme = initialTheme;
+		applyTheme(initialTheme);
+	});
+
+	function toggleTheme() {
+		theme = theme === 'light' ? 'dark' : 'light';
+		applyTheme(theme);
+		localStorage.setItem(THEME_KEY, theme);
+	}
 </script>
 
 <svelte:head>
@@ -23,7 +48,7 @@
 <div class="site-shell">
 	<header class="site-header">
 		<nav class="container nav-shell" aria-label="Navigasi utama">
-			<a href={resolve('/')} class="brand-mark">bansos.dev</a>
+			<a href={resolve('/')} class="brand-mark">Bansos Developer</a>
 			<div class="desktop-nav">
 				{#each navItems as item (item.href)}
 					<a
@@ -32,7 +57,15 @@
 					>
 				{/each}
 			</div>
-			<GithubBadge />
+			<button
+				type="button"
+				class="theme-toggle"
+				onclick={toggleTheme}
+				aria-label={theme === 'light' ? 'Aktifkan dark mode' : 'Aktifkan white mode'}
+			>
+				<i class={theme === 'light' ? 'fa-solid fa-moon' : 'fa-solid fa-sun'} aria-hidden="true"
+				></i>
+			</button>
 		</nav>
 	</header>
 
@@ -78,7 +111,7 @@
 		padding-top: 1px;
 		z-index: 50;
 		border-bottom: 1px solid var(--border-color);
-		background: rgba(9, 10, 15, 0.82);
+		background: color-mix(in srgb, var(--bg-primary) 86%, transparent);
 		backdrop-filter: blur(18px);
 	}
 
@@ -114,12 +147,35 @@
 
 	.desktop-nav a:hover {
 		color: var(--text-primary);
-		background: rgba(255, 255, 255, 0.05);
+		background: color-mix(in srgb, var(--text-primary) 5%, transparent);
 	}
 
 	.desktop-nav a.active {
 		color: var(--color-accent);
 		background: rgba(16, 185, 129, 0.1);
+	}
+
+	.theme-toggle {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.5rem;
+		height: 2.5rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.75rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		color: var(--text-secondary);
+		cursor: pointer;
+		transition:
+			background-color 0.2s,
+			color 0.2s,
+			border-color 0.2s;
+	}
+
+	.theme-toggle:hover {
+		color: var(--text-primary);
+		background: color-mix(in srgb, var(--text-primary) 8%, transparent);
+		border-color: var(--text-secondary);
 	}
 
 	.site-footer {
@@ -162,7 +218,7 @@
 		padding: 0.35rem;
 		border: 1px solid var(--border-color);
 		border-radius: 1rem;
-		background: rgba(9, 10, 15, 0.9);
+		background: color-mix(in srgb, var(--bg-primary) 92%, transparent);
 		backdrop-filter: blur(18px);
 		box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28);
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 	const repoUrl = `https://github.com/${repo}`;
 
 	// SEO metadata
-	const metaTitle = 'Bansos Dev - Bantuan Sosial untuk Developer Jelata';
+	const metaTitle = 'Bansos Developer - Bantuan Sosial untuk Developer Jelata';
 	const metaDescription =
 		'Kumpulan promo gratisan, diskon, dan bantuan sosial (bansos) khusus untuk developer jelata di Indonesia. Domain gratis, cloud gratis, no credit card! fr fr 🚀';
 	const siteUrl = 'https://bansos.dev';
@@ -121,7 +121,7 @@
 			</a>
 		</div>
 
-		<h1 class="main-title text-gradient text-balance">bansos.dev</h1>
+		<h1 class="main-title text-gradient text-balance">bansos Developer</h1>
 		<p class="tagline text-gradient">"Bantuan sosial untuk developer jelata"</p>
 
 		<!-- Anxious Sweating Computer SVG -->
@@ -142,7 +142,7 @@
 					stroke="var(--color-accent)"
 					stroke-width="4"
 				/>
-				<rect x="20" y="20" width="60" height="40" rx="4" fill="#0d0e15" />
+				<rect x="20" y="20" width="60" height="40" rx="4" fill="var(--bg-primary)" />
 				<path
 					d="M40 65 L35 80 L65 80 L60 65 Z"
 					fill="var(--bg-secondary)"
@@ -401,7 +401,7 @@
 		gap: 0.15rem;
 		border: 1px solid var(--border-color);
 		border-radius: 0.75rem;
-		background: rgba(255, 255, 255, 0.04);
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
 		padding: 0.8rem 0.75rem;
 	}
 
@@ -607,9 +607,9 @@
 		width: 2.35rem;
 		height: 2.35rem;
 		margin-left: -0.75rem;
-		border: 2px solid rgba(9, 10, 15, 0.95);
+		border: 2px solid var(--bg-primary);
 		border-radius: 999px;
-		background: rgba(255, 255, 255, 0.08);
+		background: color-mix(in srgb, var(--text-primary) 8%, transparent);
 		box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
 	}
 
@@ -650,7 +650,7 @@
 		gap: 0.35rem;
 		border: 1px solid var(--border-color);
 		border-radius: 999px;
-		background: rgba(255, 255, 255, 0.04);
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
 		color: var(--text-secondary);
 		padding: 0.4rem 0.75rem;
 		font-size: 0.85rem;
@@ -659,7 +659,7 @@
 
 	.repo-stat:hover {
 		color: var(--text-primary);
-		background: rgba(255, 255, 255, 0.08);
+		background: color-mix(in srgb, var(--text-primary) 8%, transparent);
 	}
 
 	.repo-stat i,

--- a/src/routes/contribute/+page.svelte
+++ b/src/routes/contribute/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import GithubBadge from '$lib/components/GithubBadge.svelte';
 	import { getContributorStats, type ContributorSummary } from '$lib/data/bansos';
 
 	const contributors: ContributorSummary[] = getContributorStats();
@@ -59,6 +60,11 @@
 			bikin Pull Request otomatis kalau payload JSON valid. Isi minimalnya: nama program,
 			provider, benefit, syarat klaim, masa berlaku, link official, tag, dan nama kontributor.
 		</p>
+
+		<div class="repo-status-card">
+			<p class="eyebrow">Open Source Repo</p>
+			<GithubBadge />
+		</div>
 
 		<div class="command-box">
 			<p>Contoh submit via CLI (format lengkap yang diterima):</p>
@@ -210,7 +216,18 @@
 		gap: 0.75rem;
 		border: 1px solid var(--border-color);
 		border-radius: 0.75rem;
-		background: rgba(255, 255, 255, 0.04);
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		padding: 1rem;
+	}
+
+	.repo-status-card {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 0.65rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.75rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
 		padding: 1rem;
 	}
 
@@ -222,7 +239,7 @@
 		border-radius: 0.75rem;
 		background:
 			linear-gradient(135deg, rgba(53, 194, 124, 0.12), rgba(255, 255, 255, 0.03)),
-			rgba(255, 255, 255, 0.04);
+			color-mix(in srgb, var(--text-primary) 4%, transparent);
 		padding: 1rem;
 	}
 

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -626,6 +626,13 @@
 		}
 	}
 
+	@media (max-width: 64rem) {
+		.page-wrapper {
+			padding-block: 1.5rem 2.5rem;
+			gap: 2rem;
+		}
+	}
+
 	@media (max-width: 48rem) {
 		.refresh-text {
 			display: none;


### PR DESCRIPTION
## What changed

- Rename the header brand from `bansos.dev` to `Bansos Developer`.
- Rename the homepage hero title to `bansos Developer`.
- Remove the GitHub repository badge from the global header.
- Move the GitHub repository badge into the `/contribute` page.
- Add a persistent white/dark mode toggle in the header.
- Add explicit `data-theme` theme variables so white mode works independent of system theme.
- Make affected homepage/contribute surfaces use theme-aware backgrounds.
- Darken text-gradient headings in white mode so homepage, about, and contribute headings stay readable.
- Tighten the top spacing on the `/list` page for mobile/tablet-sized viewports.

## Validation

- `npm run check`
- `git diff --check`
- Browser check: homepage brand shows `Bansos Developer`, hero shows `bansos Developer`, and the header no longer shows the repo badge.
- Browser check: white mode changes the page to light colors and persists after navigating to `/contribute`.
- Browser check: `/contribute` shows the GitHub repo badge while the header remains clean.
- Browser check: light-mode heading gradient now uses darker green values on home/about/contribute.
- Browser check: `/list` mobile/tablet viewport title top moved from about 162px to about 114px.
