### PR TITLE
Add auto-generated provider pages

### DIFF
--- a/.github/workflows/add-bansos.yml
+++ b/.github/workflows/add-bansos.yml
@@ -29,13 +29,16 @@ jobs:
         env:
           BANSOS_PAYLOAD: ${{ inputs.payload }}
 
+      - name: Generate commit contributors
+        run: npm run generate:commit-contributors
+
       - run: npm run build
 
       - name: Commit changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/lib/data/bansos.json
+          git add src/lib/data/bansos.json src/lib/data/commit-contributors.json
           git commit -m "feat: add bansos from CLI"
           git push
 

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Add bansos item
         run: npm run add:bansos -- --json .tmp-bansos-issue.json
 
+      - name: Generate commit contributors
+        run: npm run generate:commit-contributors
+
       - name: Build site
         run: npm run build
 
@@ -49,7 +52,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$branch"
-          git add src/lib/data/bansos.json
+          git add src/lib/data/bansos.json src/lib/data/commit-contributors.json
           git commit -m "feat: add ${ITEM_TITLE}"
           git push --force origin "$branch"
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ npx bansosdev add \
   --published-at 2026-06-13 \
   --requirements "Buat akun|Klaim program" \
   --cta-link "https://example.com" \
+  --source "https://example.com/source" \
   --contributor-name "Nama Kamu" \
   --contributor-url "https://example.com" \
   --tags "Cloud,Gratisan" \
@@ -100,6 +101,7 @@ npx bansosdev add \
 - `--validity-date` wajib jika `--validity-type fixed`, memakai format `YYYY-MM-DD`.
 - `--validity-desc` opsional untuk catatan masa berlaku, kuota, atau syarat khusus.
 - `--published-at` opsional untuk tanggal publikasi entry dalam format `YYYY-MM-DD`.
+- `--source` opsional untuk sumber verifikasi; bisa berupa URL atau teks biasa.
 
 ### Cek payload JSON
 
@@ -120,6 +122,7 @@ npm run add:bansos -- \
   --validity-date 2026-06-30 \
   --requirements "Buat akun|Klaim program" \
   --cta-link "https://example.com" \
+  --source "https://example.com/source" \
   --contributor-name "Nama Kamu" \
   --contributor-url "https://example.com" \
   --tags "Cloud,Gratisan"

--- a/docs/bansosdev-cli.md
+++ b/docs/bansosdev-cli.md
@@ -23,6 +23,7 @@ npx bansosdev add \
   --published-at "2026-06-13" \
   --requirements "Buat akun|Klaim program" \
   --cta-link "https://example.com" \
+  --source "https://example.com/source" \
   --contributor-name "Nama Kamu" \
   --contributor-url "https://example.com" \
   --tags "Cloud,Gratisan" \
@@ -43,6 +44,7 @@ BANSOSDEV_GITHUB_TOKEN=ghp_xxx npx bansosdev add \
   --validity-date "2026-06-30" \
   --requirements "Buat akun|Klaim program" \
   --cta-link "https://example.com" \
+  --source "https://example.com/source" \
   --contributor-name "Nama Kamu" \
   --contributor-url "https://example.com" \
   --tags "Cloud,Gratisan"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2873,24 +2873,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/yaml": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2913,7 +2895,7 @@
 		},
 		"packages/bansosdev-cli": {
 			"name": "bansosdev",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"license": "MIT",
 			"bin": {
 				"bansosdev": "bin/bansosdev.mjs"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"add:bansos": "node scripts/add-bansos.mjs",
+		"generate:commit-contributors": "node scripts/generate-commit-contributors.mjs",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",

--- a/packages/bansosdev-cli/README.md
+++ b/packages/bansosdev-cli/README.md
@@ -26,6 +26,7 @@ npx bansosdev add \
   --published-at 2026-06-13 \
   --requirements "Daftar akun|Klaim program" \
   --cta-link "https://example.com" \
+  --source "https://example.com/source" \
   --contributor-name "Nama Kamu" \
   --contributor-url "https://example.com" \
   --tags "Cloud,Gratisan"
@@ -38,6 +39,7 @@ Data validity menggunakan format terstruktur untuk mempermudah filter dan tampil
 - `--validity-type`: **(Wajib)** Enum: `fixed` | `uncertain` | `forever`.
 - `--validity-date`: **(Wajib jika type=fixed)** Format ISO `YYYY-MM-DD`. Sistem akan otomatis men-set status menjadi expired jika waktu lokal server melebihi tanggal ini.
 - `--validity-desc`: _(Opsional)_ Deskripsi/catatan tambahan yang akan di-render sebagai tooltip pada UI.
+- `--source`: _(Opsional)_ Sumber verifikasi; bisa berupa URL atau teks biasa.
 
 Contoh input `forever` (tanpa date):
 

--- a/packages/bansosdev-cli/bin/bansosdev.mjs
+++ b/packages/bansosdev-cli/bin/bansosdev.mjs
@@ -50,6 +50,7 @@ Optional:
   --published-at YYYY-MM-DD
   --promo-code CODE
   --tips "Tips singkat"
+  --source "https://example.com/source atau teks sumber"
   --contributor-name "Nama"
   --contributor-url "https://example.com"
   --status active|expired|upcoming
@@ -138,6 +139,7 @@ function payloadFromArgs(args) {
 		validity: validity,
 		requirements: list(required(args, 'requirements')),
 		tips: args.tips,
+		source: args.source,
 		publishedAt,
 		contributor:
 			args['contributor-name'] && args['contributor-url']

--- a/packages/bansosdev-cli/package.json
+++ b/packages/bansosdev-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bansosdev",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "CLI untuk submit dan menambahkan daftar bansos.dev.",
 	"type": "module",
 	"bin": {

--- a/scripts/add-bansos.mjs
+++ b/scripts/add-bansos.mjs
@@ -101,9 +101,7 @@ const contributorName =
 const contributorUrl =
 	mergedArgs['contributor-url'] || mergedArgs.contributorUrl || mergedArgs.contributor?.url;
 const publishedAt =
-	mergedArgs['published-at'] ||
-	mergedArgs.publishedAt ||
-	new Date().toISOString().slice(0, 10);
+	mergedArgs['published-at'] || mergedArgs.publishedAt || new Date().toISOString().slice(0, 10);
 
 if (!isValidCalendarDate(publishedAt)) {
 	throw new Error('publishedAt must be a valid YYYY-MM-DD date');
@@ -124,6 +122,7 @@ const item = {
 		: list(required(mergedArgs, 'requirements')),
 	tips: mergedArgs.tips,
 	publishedAt,
+	source: mergedArgs.source,
 	contributor:
 		contributorName && contributorUrl
 			? {

--- a/scripts/generate-commit-contributors.mjs
+++ b/scripts/generate-commit-contributors.mjs
@@ -1,0 +1,65 @@
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const dataPath = 'src/lib/data/bansos.json';
+const outputPath = 'src/lib/data/commit-contributors.json';
+
+function git(args) {
+	return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function parseDataAt(rev) {
+	try {
+		const raw = git(['show', `${rev}:${dataPath}`]);
+		return JSON.parse(raw);
+	} catch {
+		return [];
+	}
+}
+
+function contributorFrom(commit) {
+	const [hash, name, email] = git(['show', '-s', '--format=%H%x00%an%x00%ae', commit]).split('\0');
+	const noreply = email.match(/(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/);
+	const login =
+		noreply?.[1] ||
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9-]+/g, '-')
+			.replace(/^-+|-+$/g, '');
+	return {
+		login,
+		name,
+		avatarUrl: `https://github.com/${login}.png?size=96`,
+		commitUrl: `https://github.com/wauputr4/bansos/commit/${hash}`
+	};
+}
+
+function byId(items) {
+	return new Map(items.map((item) => [item.id, JSON.stringify(item)]));
+}
+
+const commits = git(['log', '--reverse', '--format=%H', '--', dataPath])
+	.split('\n')
+	.filter(Boolean);
+const contributorsByItem = new Map();
+
+for (const commit of commits) {
+	const before = byId(parseDataAt(`${commit}^`));
+	const after = byId(parseDataAt(commit));
+	const contributor = contributorFrom(commit);
+
+	for (const [id, item] of after.entries()) {
+		if (before.get(id) === item) continue;
+		const current = contributorsByItem.get(id) || [];
+		if (!current.some((entry) => entry.login === contributor.login)) {
+			current.push(contributor);
+		}
+		contributorsByItem.set(id, current);
+	}
+}
+
+const output = Object.fromEntries(
+	[...contributorsByItem.entries()].sort(([a], [b]) => a.localeCompare(b))
+);
+writeFileSync(outputPath, `${JSON.stringify(output, null, '\t')}\n`);
+console.log(`Generated ${outputPath}`);

--- a/scripts/generate-commit-contributors.mjs
+++ b/scripts/generate-commit-contributors.mjs
@@ -1,11 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 
 const dataPath = 'src/lib/data/bansos.json';
 const outputPath = 'src/lib/data/commit-contributors.json';
 
 function git(args) {
-	return execFileSync('git', args, { encoding: 'utf8' }).trim();
+	return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
 }
 
 function parseDataAt(rev) {
@@ -34,6 +34,34 @@ function contributorFrom(commit) {
 	};
 }
 
+function currentContributor() {
+	let name = process.env.GITHUB_ACTOR || 'local';
+	let email = `${name}@users.noreply.github.com`;
+
+	try {
+		name = git(['config', 'user.name']) || name;
+		email = git(['config', 'user.email']) || email;
+	} catch {
+		// Git config is optional for local generation.
+	}
+
+	const login =
+		process.env.GITHUB_ACTOR ||
+		email.match(/(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/)?.[1] ||
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9-]+/g, '-')
+			.replace(/^-+|-+$/g, '') ||
+		'local';
+
+	return {
+		login,
+		name,
+		avatarUrl: `https://github.com/${login}.png?size=96`,
+		commitUrl: `https://github.com/wauputr4/bansos/commits?author=${login}`
+	};
+}
+
 function byId(items) {
 	return new Map(items.map((item) => [item.id, JSON.stringify(item)]));
 }
@@ -56,6 +84,19 @@ for (const commit of commits) {
 		}
 		contributorsByItem.set(id, current);
 	}
+}
+
+const headData = byId(parseDataAt('HEAD'));
+const workingTreeData = byId(JSON.parse(readFileSync(dataPath, 'utf8')));
+const workingTreeContributor = currentContributor();
+
+for (const [id, item] of workingTreeData.entries()) {
+	if (headData.get(id) === item) continue;
+	const current = contributorsByItem.get(id) || [];
+	if (!current.some((entry) => entry.login === workingTreeContributor.login)) {
+		current.push(workingTreeContributor);
+	}
+	contributorsByItem.set(id, current);
 }
 
 const output = Object.fromEntries(

--- a/src/lib/components/BansosCard.svelte
+++ b/src/lib/components/BansosCard.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import { slugifyProvider, type BansosItem } from '$lib/data/bansos';
+	import { getProviderBySlug, slugifyProvider, type BansosItem } from '$lib/data/bansos';
 
 	let { item, compact = false }: { item: BansosItem; compact?: boolean } = $props();
 
 	let showTooltip = $state(false);
+	const providerSlug = $derived(slugifyProvider(item.provider));
+	const provider = $derived(getProviderBySlug(providerSlug));
 
 	function toggleTooltip(e: Event) {
 		e.preventDefault();
@@ -32,7 +34,11 @@
 	<div class="provider-row">
 		<p class="provider-label">
 			Provider:
-			<a href={resolve(`/providers/${slugifyProvider(item.provider)}`)}>{item.provider}</a>
+			{#if provider}
+				<a href={resolve(`/providers/${providerSlug}`)}>{item.provider}</a>
+			{:else}
+				<strong>{item.provider}</strong>
+			{/if}
 		</p>
 		{#if item.status !== 'expired'}
 			{#if item.validity.description}

--- a/src/lib/components/BansosCard.svelte
+++ b/src/lib/components/BansosCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { resolve } from '$app/paths';
-	import type { BansosItem } from '$lib/data/bansos';
+	import { slugifyProvider, type BansosItem } from '$lib/data/bansos';
 
 	let { item, compact = false }: { item: BansosItem; compact?: boolean } = $props();
 
@@ -30,7 +30,10 @@
 
 	<h2 class="card-title">{item.title}</h2>
 	<div class="provider-row">
-		<p class="provider-label">Provider: <strong>{item.provider}</strong></p>
+		<p class="provider-label">
+			Provider:
+			<a href={resolve(`/providers/${slugifyProvider(item.provider)}`)}>{item.provider}</a>
+		</p>
 		{#if item.status !== 'expired'}
 			{#if item.validity.description}
 				<button
@@ -187,6 +190,11 @@
 
 	.provider-label {
 		margin: 0;
+	}
+
+	.provider-label a {
+		color: var(--color-accent);
+		font-weight: 800;
 	}
 
 	.validity-text {

--- a/src/lib/components/SiteShell.svelte
+++ b/src/lib/components/SiteShell.svelte
@@ -12,6 +12,7 @@
 		{ href: '/', label: 'Beranda', icon: 'fa-solid fa-house' },
 		{ href: '/list', label: 'Bansos', icon: 'fa-solid fa-list' },
 		{ href: '/contribute', label: 'Kontribusi', icon: 'fa-solid fa-plus' },
+		{ href: '/providers', label: 'Provider', icon: 'fa-solid fa-building' },
 		{ href: '/about', label: 'Tentang', icon: 'fa-solid fa-circle-question' }
 	] as const;
 
@@ -71,6 +72,7 @@
 			<p>© 2026 <a href={resolve('/')}>bansos.dev</a>. Bantuan sosial untuk developer jelata.</p>
 			<div class="footer-links">
 				<a href={resolve('/about')}>Tentang</a>
+				<a href={resolve('/providers')}>Provider</a>
 				<a href={resolve('/contribute')}>Kontribusi</a>
 				<a href={resolve('/terms')}>Terms</a>
 				<span class="dot">·</span>
@@ -208,7 +210,7 @@
 		bottom: 0.75rem;
 		z-index: 60;
 		display: grid;
-		grid-template-columns: repeat(4, 1fr);
+		grid-template-columns: repeat(5, 1fr);
 		gap: 0.25rem;
 		padding: 0.35rem;
 		border: 1px solid var(--border-color);

--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -1,4 +1,5 @@
 import bansosData from './bansos.json';
+import commitContributorsData from './commit-contributors.json';
 
 export interface BansosItem {
 	id: string;
@@ -20,6 +21,7 @@ export interface BansosItem {
 		name: string;
 		url: string;
 	};
+	source?: string;
 	ctaLink: string;
 	tags: string[];
 	featured: boolean;
@@ -43,6 +45,13 @@ export interface ProviderSummary {
 	upcomingCount: number;
 	tags: string[];
 	items: BansosItem[];
+}
+
+export interface CommitContributor {
+	login: string;
+	name: string;
+	avatarUrl: string;
+	commitUrl: string;
 }
 
 const DEFAULT_UTM = {
@@ -136,9 +145,7 @@ export function recommendedBansosFor(
 		.filter((entry) => entry.status === 'active')
 		.map((entry) => ({
 			entry,
-			score:
-				entry.tags.filter((tag) => currentTags.has(tag)).length * 10 +
-				(entry.featured ? 2 : 0)
+			score: entry.tags.filter((tag) => currentTags.has(tag)).length * 10 + (entry.featured ? 2 : 0)
 		}))
 		.sort((a, b) => b.score - a.score)
 		.slice(0, limit)
@@ -156,6 +163,38 @@ export function getBansosById(id: string) {
 export function getBansosByTag(tag: string) {
 	return bansosList.filter((item) => item.tags.includes(tag));
 }
+
+export function getItemSource(item: BansosItem) {
+	return item.source || item.ctaLink;
+}
+
+export function getCommitContributorsForItem(id: string): CommitContributor[] {
+	return (commitContributorsData as Record<string, CommitContributor[]>)[id] || [];
+}
+
+export function getCommitContributorStats() {
+	const map = new Map<string, CommitContributor & { count: number }>();
+
+	for (const contributors of Object.values(
+		commitContributorsData as Record<string, CommitContributor[]>
+	)) {
+		for (const contributor of contributors) {
+			const current = map.get(contributor.login);
+			if (current) {
+				current.count += 1;
+			} else {
+				map.set(contributor.login, { ...contributor, count: 1 });
+			}
+		}
+	}
+
+	return Array.from(map.values()).sort((a, b) => {
+		if (b.count !== a.count) return b.count - a.count;
+		return a.login.localeCompare(b.login);
+	});
+}
+
+export const commitContributorCount = getCommitContributorStats().length;
 
 export function slugifyProvider(provider: string) {
 	return provider

--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -76,8 +76,27 @@ export function addTrackedCtaLink(item: BansosItem): BansosItem {
 	};
 }
 
-export const bansosList: BansosItem[] = (bansosData as BansosItem[]).map((item) =>
-	addTrackedCtaLink(item)
+export function normalizeBansosStatuses(items: BansosItem[], referenceDate = new Date()) {
+	const todayStr = Number.isNaN(referenceDate.getTime())
+		? new Date().toISOString().split('T')[0]
+		: referenceDate.toISOString().split('T')[0];
+
+	return items.map((item) => {
+		if (
+			item.status !== 'expired' &&
+			item.validity.type === 'fixed' &&
+			item.validity.date &&
+			item.validity.date < todayStr
+		) {
+			return { ...item, status: 'expired' as const };
+		}
+
+		return item;
+	});
+}
+
+export const bansosList: BansosItem[] = normalizeBansosStatuses(
+	(bansosData as BansosItem[]).map((item) => addTrackedCtaLink(item))
 );
 
 function itemDateValue(item: BansosItem, fallbackIndex: number) {
@@ -169,10 +188,16 @@ function faviconUrlFor(url: string) {
 	}
 }
 
+let cachedProviderStats: ProviderSummary[] | null = null;
+
 export function getProviderStats(items: BansosItem[] = bansosList) {
+	if (items === bansosList && cachedProviderStats) {
+		return cachedProviderStats;
+	}
+
 	const map = new Map<string, ProviderSummary>();
 
-	for (const item of items) {
+	for (const item of normalizeBansosStatuses(items)) {
 		const key = providerKey(item.provider);
 		const current = map.get(key);
 		const websiteUrl = providerWebsiteFrom(item);
@@ -183,9 +208,7 @@ export function getProviderStats(items: BansosItem[] = bansosList) {
 			current.activeCount += item.status === 'active' ? 1 : 0;
 			current.expiredCount += item.status === 'expired' ? 1 : 0;
 			current.upcomingCount += item.status === 'upcoming' ? 1 : 0;
-			current.tags = Array.from(new Set([...current.tags, ...item.tags])).sort((a, b) =>
-				a.localeCompare(b)
-			);
+			current.tags.push(...item.tags);
 		} else {
 			map.set(key, {
 				name: item.provider,
@@ -196,15 +219,16 @@ export function getProviderStats(items: BansosItem[] = bansosList) {
 				activeCount: item.status === 'active' ? 1 : 0,
 				expiredCount: item.status === 'expired' ? 1 : 0,
 				upcomingCount: item.status === 'upcoming' ? 1 : 0,
-				tags: [...item.tags].sort((a, b) => a.localeCompare(b)),
+				tags: [...item.tags],
 				items: [item]
 			});
 		}
 	}
 
-	return Array.from(map.values())
+	const result = Array.from(map.values())
 		.map((provider) => ({
 			...provider,
+			tags: Array.from(new Set(provider.tags)).sort((a, b) => a.localeCompare(b)),
 			items: sortBansosByNewest(provider.items)
 		}))
 		.sort((a, b) => {
@@ -212,6 +236,12 @@ export function getProviderStats(items: BansosItem[] = bansosList) {
 			if (b.totalCount !== a.totalCount) return b.totalCount - a.totalCount;
 			return a.name.localeCompare(b.name);
 		});
+
+	if (items === bansosList) {
+		cachedProviderStats = result;
+	}
+
+	return result;
 }
 
 export function getProviderBySlug(slug: string) {

--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -32,6 +32,19 @@ export interface ContributorSummary {
 	count: number;
 }
 
+export interface ProviderSummary {
+	name: string;
+	slug: string;
+	websiteUrl: string;
+	faviconUrl: string;
+	totalCount: number;
+	activeCount: number;
+	expiredCount: number;
+	upcomingCount: number;
+	tags: string[];
+	items: BansosItem[];
+}
+
 const DEFAULT_UTM = {
 	source: 'bansos.dev',
 	medium: 'referral',
@@ -123,6 +136,86 @@ export function getBansosById(id: string) {
 
 export function getBansosByTag(tag: string) {
 	return bansosList.filter((item) => item.tags.includes(tag));
+}
+
+export function slugifyProvider(provider: string) {
+	return provider
+		.trim()
+		.toLowerCase()
+		.replace(/&/g, ' and ')
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-+|-+$/g, '');
+}
+
+function providerKey(provider: string) {
+	return slugifyProvider(provider);
+}
+
+function providerWebsiteFrom(item: BansosItem) {
+	try {
+		const parsed = new URL(item.ctaLink);
+		return parsed.origin;
+	} catch {
+		return item.ctaLink;
+	}
+}
+
+function faviconUrlFor(url: string) {
+	try {
+		const parsed = new URL(url);
+		return `https://www.google.com/s2/favicons?domain=${parsed.hostname}&sz=128`;
+	} catch {
+		return '';
+	}
+}
+
+export function getProviderStats(items: BansosItem[] = bansosList) {
+	const map = new Map<string, ProviderSummary>();
+
+	for (const item of items) {
+		const key = providerKey(item.provider);
+		const current = map.get(key);
+		const websiteUrl = providerWebsiteFrom(item);
+
+		if (current) {
+			current.items.push(item);
+			current.totalCount += 1;
+			current.activeCount += item.status === 'active' ? 1 : 0;
+			current.expiredCount += item.status === 'expired' ? 1 : 0;
+			current.upcomingCount += item.status === 'upcoming' ? 1 : 0;
+			current.tags = Array.from(new Set([...current.tags, ...item.tags])).sort((a, b) =>
+				a.localeCompare(b)
+			);
+		} else {
+			map.set(key, {
+				name: item.provider,
+				slug: key,
+				websiteUrl,
+				faviconUrl: item.providerLogoUrl || faviconUrlFor(websiteUrl),
+				totalCount: 1,
+				activeCount: item.status === 'active' ? 1 : 0,
+				expiredCount: item.status === 'expired' ? 1 : 0,
+				upcomingCount: item.status === 'upcoming' ? 1 : 0,
+				tags: [...item.tags].sort((a, b) => a.localeCompare(b)),
+				items: [item]
+			});
+		}
+	}
+
+	return Array.from(map.values())
+		.map((provider) => ({
+			...provider,
+			items: sortBansosByNewest(provider.items)
+		}))
+		.sort((a, b) => {
+			if (b.activeCount !== a.activeCount) return b.activeCount - a.activeCount;
+			if (b.totalCount !== a.totalCount) return b.totalCount - a.totalCount;
+			return a.name.localeCompare(b.name);
+		});
+}
+
+export function getProviderBySlug(slug: string) {
+	return getProviderStats().find((provider) => provider.slug === slug);
 }
 
 function contributorKey(name: string, url: string) {

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -1,0 +1,190 @@
+{
+	"aiclass-asean-courses": [
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/d5f8f7a6164d424d409980a9bf0121576077acb6"
+		}
+	],
+	"amd-ai-dev-program": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"aws-activate-credits": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"dahono-labs-ai-api": [
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/52f2a90e047f8cb2c31851f55e0e40b989ac9eb6"
+		}
+	],
+	"deepseek-free-token": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
+		}
+	],
+	"digitalocean-hatch": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"google-startups-cloud": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"idwebhost-domain-gratis-1tahun": [
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e88f4b9151a8ad412aebefcb64a783f6437cb349"
+		}
+	],
+	"inceptionlabs-get-started": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
+		}
+	],
+	"kie-ai-api-discount-credit": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
+		}
+	],
+	"kimchi-dev-serverless-ai": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
+		}
+	],
+	"microsoft-founders-hub": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"mongodb-startups": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"namecheap-hosting-trial": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/f264304560e07b2e7e58b1e37915227d2b1ee21a"
+		}
+	],
+	"namecheap-vps-hosting": [
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e88f4b9151a8ad412aebefcb64a783f6437cb349"
+		}
+	],
+	"namecom-domain-app": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/a53c64cdefcae865d843ec6b05fff598b03ccfee"
+		}
+	],
+	"tokenrouter-minimax-m3-free": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8389c12d14e04ae8109e74f705084e7443bd987f"
+		}
+	],
+	"tokenrouter-model-gateway": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
+		}
+	],
+	"xai-grok-api-credits": [
+		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	]
+}

--- a/src/lib/stores/bansos.svelte.ts
+++ b/src/lib/stores/bansos.svelte.ts
@@ -3,6 +3,7 @@ import { SvelteDate } from 'svelte/reactivity';
 import {
 	bansosList as initialBansosList,
 	addTrackedCtaLink,
+	normalizeBansosStatuses,
 	type BansosItem
 } from '$lib/data/bansos';
 
@@ -25,25 +26,17 @@ function checkExpired(data: LegacyBansosItem[], referenceDate: SvelteDate): Bans
 	if (isNaN(referenceDate.getTime())) {
 		referenceDate = new SvelteDate();
 	}
-	const todayStr = referenceDate.toISOString().split('T')[0];
-	return data.map((item) => {
-		let validityObj = item.validity;
-		if (typeof validityObj === 'string') {
-			validityObj = { type: 'uncertain' };
-		}
-
-		if (
-			item.status !== 'expired' &&
-			validityObj &&
-			validityObj.type === 'fixed' &&
-			validityObj.date
-		) {
-			if (validityObj.date < todayStr) {
-				return { ...item, validity: validityObj, status: 'expired' };
+	return normalizeBansosStatuses(
+		data.map((item) => {
+			let validityObj = item.validity;
+			if (typeof validityObj === 'string') {
+				validityObj = { type: 'uncertain' };
 			}
-		}
-		return { ...item, validity: validityObj };
-	});
+
+			return { ...item, validity: validityObj };
+		}),
+		referenceDate
+	);
 }
 
 // Perform an initial local check so SSG/SSR starts somewhat correct

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -123,6 +123,9 @@
 
 		<h1 class="main-title text-gradient text-balance">bansos Developer</h1>
 		<p class="tagline text-gradient">"Bantuan sosial untuk developer jelata"</p>
+		<p class="community-tagline text-pretty">
+			Gotong Royong dalam bantuin developer jelata lainnya untuk glow up pada projectnya
+		</p>
 
 		<!-- Anxious Sweating Computer SVG -->
 		<div class="anxious-container">
@@ -378,6 +381,15 @@
 		letter-spacing: -0.01em;
 		margin: 0;
 		opacity: 0.95;
+	}
+
+	.community-tagline {
+		max-width: 36rem;
+		color: var(--text-secondary);
+		font-size: clamp(0.95rem, 0.9rem + 0.25vw, 1.1rem);
+		font-weight: 650;
+		line-height: 1.6;
+		margin: -0.5rem 0 0;
 	}
 
 	.intro-text {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,12 @@
 	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import BansosHighlights from '$lib/components/BansosHighlights.svelte';
-	import { bansosList, latestBansos, featuredBansos } from '$lib/data/bansos';
+	import {
+		bansosList,
+		latestBansos,
+		featuredBansos,
+		getCommitContributorStats
+	} from '$lib/data/bansos';
 
 	type GithubContributor = {
 		login: string;
@@ -25,6 +30,7 @@
 	const activeBansos = bansosList.filter((item) => item.status === 'active').length;
 	const upcomingBansos = bansosList.filter((item) => item.status === 'upcoming').length;
 	const expiredBansos = bansosList.filter((item) => item.status === 'expired').length;
+	const commitContributors = getCommitContributorStats().slice(0, 8);
 	let githubStars: number | string = $state('-');
 	let githubPrs: number | string = $state('-');
 	let githubContributors: GithubContributor[] = $state([]);
@@ -245,24 +251,21 @@
 				sesama developer jelata bertahan hidup.
 			</p>
 			<div class="repo-live-panel" aria-label="Statistik repository GitHub bansos.dev">
-				<div class="contributors-stack" aria-label="Kontributor repository">
-					{#if githubContributors.length > 0}
-						{#each githubContributors as contributor (contributor.login)}
+				<div class="commit-contributor-panel">
+					<span class="repo-panel-label">Commit kontributor</span>
+					<div class="contributors-stack" aria-label="Commit kontributor bansos data">
+						{#each commitContributors as contributor (contributor.login)}
 							<a
-								href={contributor.html_url}
+								href={`https://github.com/${contributor.login}`}
 								target="_blank"
 								rel="noopener noreferrer"
 								class="contributor-avatar"
-								aria-label={`${contributor.login}, ${contributor.contributions} kontribusi`}
+								aria-label={`${contributor.login}, ${contributor.count} commit kontribusi`}
 							>
-								<img src={contributor.avatar_url} alt={contributor.login} loading="lazy" />
+								<img src={contributor.avatarUrl} alt={contributor.login} loading="lazy" />
 							</a>
 						{/each}
-					{:else}
-						<span class="avatar-skeleton"></span>
-						<span class="avatar-skeleton"></span>
-						<span class="avatar-skeleton"></span>
-					{/if}
+					</div>
 				</div>
 				<div class="repo-live-stats">
 					<a href={repoUrl} target="_blank" rel="noopener noreferrer" class="repo-stat">
@@ -608,14 +611,27 @@
 		gap: 0.85rem;
 	}
 
+	.commit-contributor-panel {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.45rem;
+	}
+
+	.repo-panel-label {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		font-weight: 850;
+		text-transform: uppercase;
+	}
+
 	.contributors-stack {
 		display: flex;
 		justify-content: center;
 		padding-left: 0.75rem;
 	}
 
-	.contributor-avatar,
-	.avatar-skeleton {
+	.contributor-avatar {
 		width: 2.35rem;
 		height: 2.35rem;
 		margin-left: -0.75rem;
@@ -642,11 +658,6 @@
 		height: 100%;
 		object-fit: cover;
 		display: block;
-	}
-
-	.avatar-skeleton {
-		display: block;
-		animation: pulse-avatar 1.5s ease-in-out infinite;
 	}
 
 	.repo-live-stats {
@@ -677,16 +688,6 @@
 	.repo-stat i,
 	.repo-stat span {
 		color: var(--color-accent);
-	}
-
-	@keyframes pulse-avatar {
-		0%,
-		100% {
-			opacity: 0.45;
-		}
-		50% {
-			opacity: 0.9;
-		}
 	}
 
 	.btn-icon {

--- a/src/routes/contribute/+page.svelte
+++ b/src/routes/contribute/+page.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
 	import GithubBadge from '$lib/components/GithubBadge.svelte';
-	import { getContributorStats, type ContributorSummary } from '$lib/data/bansos';
+	import {
+		getCommitContributorStats,
+		getContributorStats,
+		type ContributorSummary
+	} from '$lib/data/bansos';
 
 	const contributors: ContributorSummary[] = getContributorStats();
+	const commitContributors = getCommitContributorStats();
 	const singleLineExample =
 		'npx bansosdev add --id contoh-bansos --title "Contoh" --provider "Provider" --description "Deskripsi singkat" --benefits "Benefit 1|Benefit 2" --validity-type "uncertain" --validity-desc "Berlaku sampai slot habis" --requirements "Buat akun|Klaim program" --cta-link "https://example.com" --contributor-name "Nama Kamu" --contributor-url "https://example.com" --tags "Cloud,Gratisan" --status active';
 	const agentSkillInstallCommand =
@@ -57,8 +62,8 @@
 		<h1 class="text-gradient">Punya info bansos? Jangan dinikmati sendirian.</h1>
 		<p>
 			Info baru bisa ditambahkan lewat CLI. Kamu submit issue dari hasil command, lalu bot akan
-			bikin Pull Request otomatis kalau payload JSON valid. Isi minimalnya: nama program,
-			provider, benefit, syarat klaim, masa berlaku, link official, tag, dan nama kontributor.
+			bikin Pull Request otomatis kalau payload JSON valid. Isi minimalnya: nama program, provider,
+			benefit, syarat klaim, masa berlaku, link official, tag, dan nama kontributor.
 		</p>
 
 		<div class="repo-status-card">
@@ -105,9 +110,8 @@
 				<h2>Pakai skill khusus biar agent gak halu pas nambah bansos.</h2>
 				<p>
 					Kalau kamu pakai AI agent yang support Agent Skills, install skill resmi
-					<code>wauputr4/skill-bansos</code> lewat <code>npx skills</code>. Skill ini ngajarin
-					agent cara riset sumber, bikin payload valid, dan mengikuti aturan kontribusi
-					bansos.dev.
+					<code>wauputr4/skill-bansos</code> lewat <code>npx skills</code>. Skill ini ngajarin agent
+					cara riset sumber, bikin payload valid, dan mengikuti aturan kontribusi bansos.dev.
 				</p>
 			</div>
 			<div class="command-panel">
@@ -161,6 +165,11 @@
 			<h2 class="section-title">
 				<i class="fa-solid fa-users"></i> Kontributor Terdaftar
 			</h2>
+			<p class="section-note">
+				Kontributor terdaftar adalah nama yang ditulis di payload bansos. Commit kontributor adalah
+				akun GitHub yang benar-benar menambah atau mengubah data lewat commit, jadi satu bansos bisa
+				punya beberapa commit kontributor kalau pernah diupdate.
+			</p>
 			{#if contributors.length > 0}
 				<ul class="contributors-list">
 					{#each contributors as contributor (`${contributor.name}-${contributor.url}`)}
@@ -178,6 +187,27 @@
 			{:else}
 				<p class="empty-contributor">Belum ada kontributor yang terdeteksi di data.</p>
 			{/if}
+		</section>
+
+		<section class="contributors-section">
+			<h2 class="section-title">
+				<i class="fa-solid fa-code-commit"></i> Commit Kontributor
+			</h2>
+			<ul class="commit-contributors-list">
+				{#each commitContributors as contributor (contributor.login)}
+					<li class="commit-contributor-card">
+						<a
+							href={`https://github.com/${contributor.login}`}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<img src={contributor.avatarUrl} alt={contributor.login} loading="lazy" />
+							<span>@{contributor.login}</span>
+						</a>
+						<span class="contributor-count">{contributor.count} data tersentuh</span>
+					</li>
+				{/each}
+			</ul>
 		</section>
 	</section>
 </main>
@@ -384,6 +414,45 @@
 		padding: 0;
 		margin: 0;
 		list-style: none;
+	}
+
+	.section-note {
+		color: var(--text-secondary);
+		margin: -0.25rem 0 0;
+	}
+
+	.commit-contributors-list {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.75rem;
+		padding: 0;
+		margin: 0;
+		list-style: none;
+	}
+
+	.commit-contributor-card {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.7rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		padding: 0.75rem 1rem;
+	}
+
+	.commit-contributor-card a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.65rem;
+		color: var(--color-accent);
+		font-weight: 800;
+	}
+
+	.commit-contributor-card img {
+		width: 2rem;
+		height: 2rem;
+		border-radius: 999px;
 	}
 
 	.contributor-card {

--- a/src/routes/contribute/+page.svelte
+++ b/src/routes/contribute/+page.svelte
@@ -9,7 +9,7 @@
 	const contributors: ContributorSummary[] = getContributorStats();
 	const commitContributors = getCommitContributorStats();
 	const singleLineExample =
-		'npx bansosdev add --id contoh-bansos --title "Contoh" --provider "Provider" --description "Deskripsi singkat" --benefits "Benefit 1|Benefit 2" --validity-type "uncertain" --validity-desc "Berlaku sampai slot habis" --requirements "Buat akun|Klaim program" --cta-link "https://example.com" --contributor-name "Nama Kamu" --contributor-url "https://example.com" --tags "Cloud,Gratisan" --status active';
+		'npx bansosdev add --id contoh-bansos --title "Contoh" --provider "Provider" --description "Deskripsi singkat" --benefits "Benefit 1|Benefit 2" --validity-type "uncertain" --validity-desc "Berlaku sampai slot habis" --requirements "Buat akun|Klaim program" --cta-link "https://example.com" --source "https://example.com/source" --contributor-name "Nama Kamu" --contributor-url "https://example.com" --tags "Cloud,Gratisan" --status active';
 	const agentSkillInstallCommand =
 		"npx skills add wauputr4/skill-bansos --skill bansos-add-entry --agent '*'";
 	const agentPromptExample =
@@ -27,6 +27,7 @@
 		'  --promo-code "DEVWEEK26" \\',
 		'  --published-at "2026-06-11" \\',
 		'  --cta-link "https://www.name.com" \\',
+		'  --source "https://www.name.com/blog/devweek" \\',
 		'  --contributor-name "Wauputra" \\',
 		'  --contributor-url "https://wau.my.id" \\',
 		'  --tags "Domain,Gratisan,No Credit Card" \\',

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -43,6 +43,8 @@
 	let selectedValidities: string[] = $state([]);
 	let sortOrder: 'newest' | 'oldest' = $state('newest');
 	let filterExpanded = $state(false);
+	let currentPage = $state(1);
+	const pageSize = 6;
 
 	const dynamicTags = $derived(
 		Array.from(new Set(bansosState.data.flatMap((item) => item.tags))).sort((a, b) =>
@@ -64,6 +66,26 @@
 			.sort((a, b) => (sortOrder === 'newest' ? b.index - a.index : a.index - b.index))
 			.map(({ item }) => item)
 	);
+	const totalPages = $derived(Math.max(1, Math.ceil(filteredBansos.length / pageSize)));
+	const paginatedBansos = $derived(
+		filteredBansos.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+	);
+	const pageStart = $derived(filteredBansos.length === 0 ? 0 : (currentPage - 1) * pageSize + 1);
+	const pageEnd = $derived(Math.min(currentPage * pageSize, filteredBansos.length));
+
+	$effect(() => {
+		selectedTags;
+		selectedStatuses;
+		selectedValidities;
+		sortOrder;
+		currentPage = 1;
+	});
+
+	$effect(() => {
+		if (currentPage > totalPages) {
+			currentPage = totalPages;
+		}
+	});
 
 	const totalSeconds = $derived(Math.ceil(remainingTime / 1000));
 	const timerM = $derived(Math.floor(totalSeconds / 60));
@@ -320,17 +342,55 @@
 						selectedStatuses = [];
 						selectedValidities = [];
 						sortOrder = 'newest';
+						currentPage = 1;
 					}}
 				>
 					Reset Filter
 				</button>
 			</div>
 		{:else}
+			<div class="result-summary">
+				<span>Menampilkan {pageStart}-{pageEnd} dari {filteredBansos.length} bansos</span>
+				<span>Halaman {currentPage} dari {totalPages}</span>
+			</div>
 			<div class="bansos-grid">
-				{#each filteredBansos as item (item.id)}
+				{#each paginatedBansos as item (item.id)}
 					<BansosCard {item} />
 				{/each}
 			</div>
+			{#if totalPages > 1}
+				<nav class="pagination" aria-label="Pagination daftar bansos">
+					<button
+						type="button"
+						class="page-btn"
+						aria-label="Halaman sebelumnya"
+						disabled={currentPage === 1}
+						onclick={() => (currentPage = Math.max(1, currentPage - 1))}
+					>
+						<i class="fa-solid fa-chevron-left"></i>
+					</button>
+					{#each Array(totalPages) as _, index (index)}
+						<button
+							type="button"
+							class="page-btn"
+							class:active={currentPage === index + 1}
+							aria-current={currentPage === index + 1 ? 'page' : undefined}
+							onclick={() => (currentPage = index + 1)}
+						>
+							{index + 1}
+						</button>
+					{/each}
+					<button
+						type="button"
+						class="page-btn"
+						aria-label="Halaman berikutnya"
+						disabled={currentPage === totalPages}
+						onclick={() => (currentPage = Math.min(totalPages, currentPage + 1))}
+					>
+						<i class="fa-solid fa-chevron-right"></i>
+					</button>
+				</nav>
+			{/if}
 		{/if}
 	</section>
 </main>
@@ -502,6 +562,54 @@
 
 	.feed-section {
 		min-height: 40vh;
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.result-summary {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.75rem;
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		font-weight: 750;
+	}
+
+	.pagination {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.5rem;
+		padding-top: 0.75rem;
+	}
+
+	.page-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 2.4rem;
+		height: 2.4rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.65rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		color: var(--text-secondary);
+		font: inherit;
+		font-size: 0.9rem;
+		font-weight: 800;
+		cursor: pointer;
+	}
+
+	.page-btn:hover:not(:disabled),
+	.page-btn.active {
+		border-color: color-mix(in srgb, var(--color-accent) 55%, var(--border-color));
+		background: var(--color-accent-glow);
+		color: var(--color-accent);
+	}
+
+	.page-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.45;
 	}
 
 	.empty-state {

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -736,8 +736,12 @@
 
 	@media (max-width: 64rem) {
 		.page-wrapper {
-			padding-block: 1.5rem 2.5rem;
-			gap: 2rem;
+			padding-block: 0.75rem 2.5rem;
+			gap: 1.5rem;
+		}
+
+		.filter-section {
+			margin-bottom: -0.75rem;
 		}
 	}
 

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -44,6 +44,7 @@
 	let sortOrder: 'newest' | 'oldest' = $state('newest');
 	let filterExpanded = $state(false);
 	let currentPage = $state(1);
+	let searchQuery = $state('');
 	const pageSize = 6;
 
 	const dynamicTags = $derived(
@@ -56,12 +57,27 @@
 		bansosState.data
 			.map((item, index) => ({ item, index }))
 			.filter(({ item }) => {
+				const query = searchQuery.trim().toLowerCase();
+				const searchable = [
+					item.title,
+					item.provider,
+					item.description,
+					item.promoCode || '',
+					item.validity.description || '',
+					item.contributor?.name || '',
+					item.tags.join(' '),
+					item.benefits.join(' '),
+					item.requirements.join(' ')
+				]
+					.join(' ')
+					.toLowerCase();
+				const searchMatch = !query || searchable.includes(query);
 				const tagMatch =
 					selectedTags.length === 0 || item.tags.some((tag) => selectedTags.includes(tag));
 				const statusMatch = selectedStatuses.length === 0 || selectedStatuses.includes(item.status);
 				const validityMatch =
 					selectedValidities.length === 0 || selectedValidities.includes(item.validity.type);
-				return tagMatch && statusMatch && validityMatch;
+				return searchMatch && tagMatch && statusMatch && validityMatch;
 			})
 			.sort((a, b) => (sortOrder === 'newest' ? b.index - a.index : a.index - b.index))
 			.map(({ item }) => item)
@@ -78,6 +94,7 @@
 		selectedStatuses;
 		selectedValidities;
 		sortOrder;
+		searchQuery;
 		currentPage = 1;
 	});
 
@@ -188,6 +205,22 @@
 			Klik kartu bansos untuk melihat langkah-langkah detail dan cara klaim kodenya, fr fr! 🚀
 		</p>
 	</header>
+
+	<section class="search-section container" aria-label="Pencarian bansos">
+		<label class="search-box">
+			<i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+			<input
+				type="search"
+				bind:value={searchQuery}
+				placeholder="Cari nama, provider, benefit, tag, kontributor..."
+			/>
+			{#if searchQuery}
+				<button type="button" aria-label="Bersihkan pencarian" onclick={() => (searchQuery = '')}>
+					<i class="fa-solid fa-xmark"></i>
+				</button>
+			{/if}
+		</label>
+	</section>
 
 	<section class="filter-section container" aria-label="Filter tag bansos">
 		<div class="filter-card">
@@ -342,6 +375,7 @@
 						selectedStatuses = [];
 						selectedValidities = [];
 						sortOrder = 'newest';
+						searchQuery = '';
 						currentPage = 1;
 					}}
 				>
@@ -440,6 +474,45 @@
 
 	.filter-section {
 		margin-bottom: -1.5rem;
+	}
+
+	.search-section {
+		margin-bottom: -2.5rem;
+	}
+
+	.search-box {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		border: 1px solid var(--glass-border);
+		border-radius: 1rem;
+		background: linear-gradient(var(--glass-bg), var(--glass-bg)) var(--bg-primary);
+		padding: 0.85rem 1rem;
+		color: var(--text-secondary);
+	}
+
+	.search-box:focus-within {
+		border-color: color-mix(in srgb, var(--color-accent) 55%, var(--border-color));
+		box-shadow: 0 0 0 3px var(--color-accent-glow);
+	}
+
+	.search-box input {
+		width: 100%;
+		border: 0;
+		outline: 0;
+		background: transparent;
+		color: var(--text-primary);
+		font: inherit;
+		font-weight: 650;
+		min-width: 0;
+	}
+
+	.search-box button {
+		border: 0;
+		background: transparent;
+		color: var(--text-secondary);
+		cursor: pointer;
+		font: inherit;
 	}
 
 	.filter-card {
@@ -742,6 +815,10 @@
 
 		.filter-section {
 			margin-bottom: -0.75rem;
+		}
+
+		.search-section {
+			margin-bottom: -1rem;
 		}
 	}
 

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -218,7 +218,12 @@
 						{/if}
 						<p class="detail-subtitle">
 							Disponsori oleh
-							<a href={resolve(`/providers/${slugifyProvider(item.provider)}`)}>{item.provider}</a>
+							{#if provider}
+								<a href={resolve(`/providers/${slugifyProvider(item.provider)}`)}>{item.provider}</a
+								>
+							{:else}
+								<strong>{item.provider}</strong>
+							{/if}
 							<span aria-hidden="true">·</span>
 							<span>Diterbitkan pada Juni 2026</span>
 						</p>

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import { resolve } from '$app/paths';
 	import FloatingEmoji from '$lib/components/FloatingEmoji.svelte';
 	import BansosCard from '$lib/components/BansosCard.svelte';
-	import { recommendedBansosFor } from '$lib/data/bansos';
+	import { recommendedBansosFor, slugifyProvider } from '$lib/data/bansos';
 	import { bansosState, initBansosStore, fetchLatestBansos } from '$lib/stores/bansos.svelte';
 	import { onMount } from 'svelte';
 
@@ -199,7 +199,9 @@
 					</div>
 					<h1 class="detail-title text-gradient text-pretty">{item.title}</h1>
 					<p class="detail-subtitle">
-						Disponsori oleh <strong>{item.provider}</strong> — Diterbitkan pada Juni 2026
+						Disponsori oleh
+						<a href={resolve(`/providers/${slugifyProvider(item.provider)}`)}>{item.provider}</a>
+						— Diterbitkan pada Juni 2026
 					</p>
 					{#if item.contributor}
 						<p class="detail-contributor">
@@ -455,6 +457,11 @@
 	.detail-subtitle {
 		font-size: 0.95rem;
 		color: var(--text-secondary);
+	}
+
+	.detail-subtitle a {
+		color: var(--color-accent);
+		font-weight: 800;
 	}
 
 	.detail-contributor {

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -2,7 +2,13 @@
 	import { resolve } from '$app/paths';
 	import FloatingEmoji from '$lib/components/FloatingEmoji.svelte';
 	import BansosCard from '$lib/components/BansosCard.svelte';
-	import { getProviderBySlug, recommendedBansosFor, slugifyProvider } from '$lib/data/bansos';
+	import {
+		getCommitContributorsForItem,
+		getItemSource,
+		getProviderBySlug,
+		recommendedBansosFor,
+		slugifyProvider
+	} from '$lib/data/bansos';
 	import { bansosState, initBansosStore, fetchLatestBansos } from '$lib/stores/bansos.svelte';
 	import { onMount } from 'svelte';
 
@@ -10,6 +16,9 @@
 
 	const item = $derived(bansosState.data.find((i) => i.id === data.id) || data.item);
 	const provider = $derived(item ? getProviderBySlug(slugifyProvider(item.provider)) : null);
+	const source = $derived(item ? getItemSource(item) : '');
+	const sourceIsUrl = $derived(/^https?:\/\//.test(source));
+	const commitContributors = $derived(item ? getCommitContributorsForItem(item.id) : []);
 
 	onMount(() => {
 		initBansosStore();
@@ -222,6 +231,37 @@
 							</a>
 						</p>
 					{/if}
+					<div class="detail-meta-grid">
+						<div class="meta-card">
+							<span class="meta-label"><i class="fa-solid fa-link"></i> Sumber</span>
+							{#if sourceIsUrl}
+								<a href={source} target="_blank" rel="noopener noreferrer">{source}</a>
+							{:else}
+								<strong>{source}</strong>
+							{/if}
+						</div>
+						{#if commitContributors.length > 0}
+							<div class="meta-card">
+								<span class="meta-label"
+									><i class="fa-solid fa-code-commit"></i> Commit kontributor</span
+								>
+								<div class="commit-list">
+									{#each commitContributors as contributor (contributor.login)}
+										<a
+											href={contributor.commitUrl}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="commit-person"
+											title={`Commit oleh ${contributor.login}`}
+										>
+											<img src={contributor.avatarUrl} alt={contributor.login} loading="lazy" />
+											<span>@{contributor.login}</span>
+										</a>
+									{/each}
+								</div>
+							</div>
+						{/if}
+					</div>
 				</header>
 
 				{#if item.status === 'expired'}
@@ -540,6 +580,64 @@
 	.detail-contributor a {
 		color: var(--color-accent);
 		font-weight: 700;
+	}
+
+	.detail-meta-grid {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+	}
+
+	.meta-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.45rem;
+		min-width: 0;
+		border: 1px solid var(--border-color);
+		border-radius: 0.75rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		padding: 0.8rem;
+	}
+
+	.meta-label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		font-weight: 850;
+		text-transform: uppercase;
+	}
+
+	.meta-card a,
+	.meta-card strong {
+		color: var(--text-primary);
+		font-size: 0.86rem;
+		font-weight: 750;
+		overflow-wrap: anywhere;
+	}
+
+	.commit-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.55rem;
+	}
+
+	.commit-person {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		border: 1px solid var(--border-color);
+		border-radius: 999px;
+		background: var(--bg-secondary);
+		padding: 0.25rem 0.55rem 0.25rem 0.25rem;
+	}
+
+	.commit-person img {
+		width: 1.5rem;
+		height: 1.5rem;
+		border-radius: 999px;
 	}
 
 	.section-block {

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -2,13 +2,14 @@
 	import { resolve } from '$app/paths';
 	import FloatingEmoji from '$lib/components/FloatingEmoji.svelte';
 	import BansosCard from '$lib/components/BansosCard.svelte';
-	import { recommendedBansosFor, slugifyProvider } from '$lib/data/bansos';
+	import { getProviderBySlug, recommendedBansosFor, slugifyProvider } from '$lib/data/bansos';
 	import { bansosState, initBansosStore, fetchLatestBansos } from '$lib/stores/bansos.svelte';
 	import { onMount } from 'svelte';
 
 	let { data } = $props();
 
 	const item = $derived(bansosState.data.find((i) => i.id === data.id) || data.item);
+	const provider = $derived(item ? getProviderBySlug(slugifyProvider(item.provider)) : null);
 
 	onMount(() => {
 		initBansosStore();
@@ -177,7 +178,11 @@
 		<!-- Top Navigation -->
 		<nav class="top-nav container">
 			<a href={resolve('/list')} class="btn-back">
-				<span class="arrow">←</span> Kembali ke List Bansos
+				<span class="back-icon" aria-hidden="true"><i class="fa-solid fa-arrow-left"></i></span>
+				<span>
+					<small>Kembali</small>
+					<strong>List Bansos</strong>
+				</span>
 			</a>
 		</nav>
 
@@ -198,11 +203,17 @@
 						</div>
 					</div>
 					<h1 class="detail-title text-gradient text-pretty">{item.title}</h1>
-					<p class="detail-subtitle">
-						Disponsori oleh
-						<a href={resolve(`/providers/${slugifyProvider(item.provider)}`)}>{item.provider}</a>
-						— Diterbitkan pada Juni 2026
-					</p>
+					<div class="provider-meta">
+						{#if provider?.faviconUrl}
+							<img src={provider.faviconUrl} alt="" loading="lazy" class="provider-logo" />
+						{/if}
+						<p class="detail-subtitle">
+							Disponsori oleh
+							<a href={resolve(`/providers/${slugifyProvider(item.provider)}`)}>{item.provider}</a>
+							<span aria-hidden="true">·</span>
+							<span>Diterbitkan pada Juni 2026</span>
+						</p>
+					</div>
 					{#if item.contributor}
 						<p class="detail-contributor">
 							Dikontribusikan oleh
@@ -330,10 +341,10 @@
 <style>
 	.page-wrapper {
 		position: relative;
-		padding-block: 2.5rem;
+		padding-block: 1.25rem 2.5rem;
 		display: flex;
 		flex-direction: column;
-		gap: 3.5rem;
+		gap: 1.25rem;
 		z-index: 1;
 	}
 
@@ -351,21 +362,57 @@
 	.btn-back {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.5rem;
-		font-weight: 600;
+		gap: 0.7rem;
+		font-weight: 750;
 		color: var(--text-secondary);
 		border: 1px solid var(--border-color);
-		padding: 0.5rem 1rem;
-		border-radius: 0.5rem;
-		background: var(--glass-bg);
+		padding: 0.45rem 0.8rem 0.45rem 0.45rem;
+		border-radius: 999px;
+		background:
+			linear-gradient(135deg, var(--color-accent-glow), transparent 80%),
+			color-mix(in srgb, var(--text-primary) 4%, transparent);
+		box-shadow: 0 12px 30px color-mix(in srgb, var(--glass-shadow) 65%, transparent);
 		transition:
 			background-color 0.2s,
-			color 0.2s;
+			border-color 0.2s,
+			color 0.2s,
+			transform 0.2s;
 	}
 
 	.btn-back:hover {
 		color: var(--text-primary);
-		background-color: rgba(255, 255, 255, 0.05);
+		border-color: color-mix(in srgb, var(--color-accent) 45%, var(--border-color));
+		transform: translateY(-1px);
+	}
+
+	.back-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		border-radius: 999px;
+		background: var(--color-accent-glow);
+		color: var(--color-accent);
+	}
+
+	.btn-back span:last-child {
+		display: flex;
+		flex-direction: column;
+		gap: 0.05rem;
+		line-height: 1.05;
+	}
+
+	.btn-back small {
+		color: var(--text-muted);
+		font-size: 0.68rem;
+		font-weight: 800;
+		text-transform: uppercase;
+	}
+
+	.btn-back strong {
+		color: var(--text-primary);
+		font-size: 0.88rem;
 	}
 
 	.detail-container {
@@ -455,6 +502,10 @@
 	}
 
 	.detail-subtitle {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.35rem;
 		font-size: 0.95rem;
 		color: var(--text-secondary);
 	}
@@ -462,6 +513,23 @@
 	.detail-subtitle a {
 		color: var(--color-accent);
 		font-weight: 800;
+	}
+
+	.provider-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+	}
+
+	.provider-logo {
+		width: 2rem;
+		height: 2rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.6rem;
+		background: var(--bg-secondary);
+		object-fit: contain;
+		padding: 0.3rem;
+		flex-shrink: 0;
 	}
 
 	.detail-contributor {

--- a/src/routes/providers/+page.svelte
+++ b/src/routes/providers/+page.svelte
@@ -5,6 +5,14 @@
 	const providers = getProviderStats();
 	const totalProviders = providers.length;
 	const totalActive = providers.reduce((sum, provider) => sum + provider.activeCount, 0);
+	let currentPage = $state(1);
+	const pageSize = 6;
+	const totalPages = Math.max(1, Math.ceil(providers.length / pageSize));
+	const paginatedProviders = $derived(
+		providers.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+	);
+	const pageStart = $derived(providers.length === 0 ? 0 : (currentPage - 1) * pageSize + 1);
+	const pageEnd = $derived(Math.min(currentPage * pageSize, providers.length));
 </script>
 
 <svelte:head>
@@ -35,29 +43,70 @@
 		</div>
 	</section>
 
-	<section class="container provider-grid" aria-label="Daftar provider">
-		{#each providers as provider (provider.slug)}
-			<a href={resolve(`/providers/${provider.slug}`)} class="provider-card glass-card">
-				<div class="provider-top">
-					<img src={provider.faviconUrl} alt="" loading="lazy" class="provider-logo" />
-					<span class="active-pill"><i class="fa-solid fa-circle"></i> {provider.activeCount} aktif</span>
-				</div>
-				<div>
-					<h2>{provider.name}</h2>
-					<p>
-						{provider.totalCount} bansos terdaftar
-						{#if provider.expiredCount > 0}
-							<span> · {provider.expiredCount} expired</span>
-						{/if}
-					</p>
-				</div>
-				<div class="tag-list">
-					{#each provider.tags.slice(0, 4) as tag (tag)}
-						<span>{tag}</span>
-					{/each}
-				</div>
-			</a>
-		{/each}
+	<section class="container provider-list" aria-label="Daftar provider">
+		<div class="result-summary">
+			<span>Menampilkan {pageStart}-{pageEnd} dari {providers.length} provider</span>
+			<span>Halaman {currentPage} dari {totalPages}</span>
+		</div>
+		<div class="provider-grid">
+			{#each paginatedProviders as provider (provider.slug)}
+				<a href={resolve(`/providers/${provider.slug}`)} class="provider-card glass-card">
+					<div class="provider-top">
+						<img src={provider.faviconUrl} alt="" loading="lazy" class="provider-logo" />
+						<span class="active-pill"
+							><i class="fa-solid fa-circle"></i> {provider.activeCount} aktif</span
+						>
+					</div>
+					<div>
+						<h2>{provider.name}</h2>
+						<p>
+							{provider.totalCount} bansos terdaftar
+							{#if provider.expiredCount > 0}
+								<span> · {provider.expiredCount} expired</span>
+							{/if}
+						</p>
+					</div>
+					<div class="tag-list">
+						{#each provider.tags.slice(0, 4) as tag (tag)}
+							<span>{tag}</span>
+						{/each}
+					</div>
+				</a>
+			{/each}
+		</div>
+		{#if totalPages > 1}
+			<nav class="pagination" aria-label="Pagination daftar provider">
+				<button
+					type="button"
+					class="page-btn"
+					aria-label="Halaman sebelumnya"
+					disabled={currentPage === 1}
+					onclick={() => (currentPage = Math.max(1, currentPage - 1))}
+				>
+					<i class="fa-solid fa-chevron-left"></i>
+				</button>
+				{#each Array(totalPages) as _, index (index)}
+					<button
+						type="button"
+						class="page-btn"
+						class:active={currentPage === index + 1}
+						aria-current={currentPage === index + 1 ? 'page' : undefined}
+						onclick={() => (currentPage = index + 1)}
+					>
+						{index + 1}
+					</button>
+				{/each}
+				<button
+					type="button"
+					class="page-btn"
+					aria-label="Halaman berikutnya"
+					disabled={currentPage === totalPages}
+					onclick={() => (currentPage = Math.min(totalPages, currentPage + 1))}
+				>
+					<i class="fa-solid fa-chevron-right"></i>
+				</button>
+			</nav>
+		{/if}
 	</section>
 </main>
 
@@ -119,6 +168,21 @@
 		color: var(--text-secondary);
 		font-size: 0.85rem;
 		font-weight: 700;
+	}
+
+	.provider-list {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.result-summary {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.75rem;
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		font-weight: 750;
 	}
 
 	.provider-grid {
@@ -199,6 +263,42 @@
 		font-size: 0.75rem;
 		font-weight: 700;
 		padding: 0.2rem 0.55rem;
+	}
+
+	.pagination {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.5rem;
+		padding-top: 0.75rem;
+	}
+
+	.page-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 2.4rem;
+		height: 2.4rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.65rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		color: var(--text-secondary);
+		font: inherit;
+		font-size: 0.9rem;
+		font-weight: 800;
+		cursor: pointer;
+	}
+
+	.page-btn:hover:not(:disabled),
+	.page-btn.active {
+		border-color: color-mix(in srgb, var(--color-accent) 55%, var(--border-color));
+		background: var(--color-accent-glow);
+		color: var(--color-accent);
+	}
+
+	.page-btn:disabled {
+		cursor: not-allowed;
+		opacity: 0.45;
 	}
 
 	@media (max-width: 48rem) {

--- a/src/routes/providers/+page.svelte
+++ b/src/routes/providers/+page.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import { getProviderStats } from '$lib/data/bansos';
+
+	const providers = getProviderStats();
+	const totalProviders = providers.length;
+	const totalActive = providers.reduce((sum, provider) => sum + provider.activeCount, 0);
+</script>
+
+<svelte:head>
+	<title>Daftar Provider Bansos Developer - bansos.dev</title>
+	<meta
+		name="description"
+		content="Lihat daftar provider bansos developer seperti cloud credit, domain gratis, hosting trial, AI credits, dan program startup yang bisa diklaim developer Indonesia."
+	/>
+</svelte:head>
+
+<main class="page-wrapper">
+	<section class="container provider-hero">
+		<p class="eyebrow">Provider</p>
+		<h1 class="text-gradient text-balance">Provider bansos developer</h1>
+		<p class="subtitle-text text-pretty">
+			Semua provider diambil otomatis dari daftar bansos. Saat ada bansos baru, halaman ini ikut
+			nambah tanpa perlu maintain manual.
+		</p>
+		<div class="stats-grid" aria-label="Ringkasan provider">
+			<div>
+				<strong>{totalProviders}</strong>
+				<span>Total provider</span>
+			</div>
+			<div>
+				<strong>{totalActive}</strong>
+				<span>Bansos aktif</span>
+			</div>
+		</div>
+	</section>
+
+	<section class="container provider-grid" aria-label="Daftar provider">
+		{#each providers as provider (provider.slug)}
+			<a href={resolve(`/providers/${provider.slug}`)} class="provider-card glass-card">
+				<div class="provider-top">
+					<img src={provider.faviconUrl} alt="" loading="lazy" class="provider-logo" />
+					<span class="active-pill"><i class="fa-solid fa-circle"></i> {provider.activeCount} aktif</span>
+				</div>
+				<div>
+					<h2>{provider.name}</h2>
+					<p>
+						{provider.totalCount} bansos terdaftar
+						{#if provider.expiredCount > 0}
+							<span> · {provider.expiredCount} expired</span>
+						{/if}
+					</p>
+				</div>
+				<div class="tag-list">
+					{#each provider.tags.slice(0, 4) as tag (tag)}
+						<span>{tag}</span>
+					{/each}
+				</div>
+			</a>
+		{/each}
+	</section>
+</main>
+
+<style>
+	.page-wrapper {
+		padding-block: 2.5rem 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+	}
+
+	.provider-hero {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.eyebrow {
+		color: var(--color-accent);
+		font-size: 0.8rem;
+		font-weight: 850;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		max-width: 46rem;
+		font-size: clamp(2rem, 1.5rem + 2vw, 3.25rem);
+		line-height: 1.08;
+	}
+
+	.subtitle-text {
+		max-width: 46rem;
+		color: var(--text-secondary);
+		font-size: 1rem;
+	}
+
+	.stats-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 12rem));
+		gap: 0.75rem;
+		margin-top: 0.5rem;
+	}
+
+	.stats-grid div {
+		border: 1px solid var(--border-color);
+		border-radius: 0.75rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		padding: 1rem;
+	}
+
+	.stats-grid strong {
+		display: block;
+		color: var(--color-accent);
+		font-size: 1.7rem;
+		line-height: 1;
+	}
+
+	.stats-grid span {
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		font-weight: 700;
+	}
+
+	.provider-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+		gap: 1rem;
+	}
+
+	.provider-card {
+		display: flex;
+		flex-direction: column;
+		gap: 1.1rem;
+		color: inherit;
+		padding: 1.25rem;
+		min-height: 13rem;
+		transition:
+			transform 0.2s,
+			border-color 0.2s;
+	}
+
+	.provider-card:hover {
+		transform: translateY(-2px);
+		border-color: color-mix(in srgb, var(--color-accent) 50%, var(--border-color));
+	}
+
+	.provider-top {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.provider-logo {
+		width: 2.75rem;
+		height: 2.75rem;
+		border-radius: 0.7rem;
+		border: 1px solid var(--border-color);
+		background: var(--bg-secondary);
+		padding: 0.45rem;
+		object-fit: contain;
+	}
+
+	.active-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		border-radius: 999px;
+		background: var(--color-success-glow);
+		color: var(--color-success);
+		font-size: 0.8rem;
+		font-weight: 800;
+		padding: 0.35rem 0.65rem;
+	}
+
+	h2 {
+		font-size: 1.2rem;
+		line-height: 1.25;
+	}
+
+	.provider-card p {
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		font-weight: 650;
+		margin-top: 0.25rem;
+	}
+
+	.tag-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.45rem;
+		margin-top: auto;
+	}
+
+	.tag-list span {
+		border: 1px solid var(--border-color);
+		border-radius: 0.45rem;
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 700;
+		padding: 0.2rem 0.55rem;
+	}
+
+	@media (max-width: 48rem) {
+		.page-wrapper {
+			padding-block: 1.5rem 6rem;
+		}
+
+		.stats-grid {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+</style>

--- a/src/routes/providers/[slug]/+page.svelte
+++ b/src/routes/providers/[slug]/+page.svelte
@@ -1,0 +1,241 @@
+<script lang="ts">
+	import { resolve } from '$app/paths';
+	import BansosCard from '$lib/components/BansosCard.svelte';
+
+	let { data } = $props();
+	const provider = $derived(data.provider);
+	const seoTitle = $derived(
+		provider ? `${provider.name} bansos developer - bansos.dev` : 'Provider tidak ditemukan'
+	);
+	const seoDescription = $derived(
+		provider
+			? `Daftar bansos developer dari ${provider.name}: ${provider.totalCount} program, ${provider.activeCount} masih aktif, lengkap dengan cara klaim dan link resmi.`
+			: ''
+	);
+</script>
+
+<svelte:head>
+	<title>{seoTitle}</title>
+	{#if provider}
+		<meta name="description" content={seoDescription} />
+		<meta property="og:title" content={seoTitle} />
+		<meta property="og:description" content={seoDescription} />
+		<meta property="og:image" content={provider.faviconUrl} />
+		<meta property="twitter:card" content="summary" />
+		<meta property="twitter:title" content={seoTitle} />
+		<meta property="twitter:description" content={seoDescription} />
+		<meta property="twitter:image" content={provider.faviconUrl} />
+	{/if}
+</svelte:head>
+
+{#if !provider}
+	<main class="page-wrapper container">
+		<section class="glass-card empty-state">
+			<h1>Provider tidak ditemukan</h1>
+			<p>Provider ini belum punya bansos yang tercatat.</p>
+			<a href={resolve('/providers')} class="btn-primary">Lihat semua provider</a>
+		</section>
+	</main>
+{:else}
+	<main class="page-wrapper">
+		<nav class="container top-nav">
+			<a href={resolve('/providers')} class="btn-back">
+				<i class="fa-solid fa-arrow-left"></i> Semua Provider
+			</a>
+		</nav>
+
+		<header class="container provider-header">
+			<div class="provider-identity">
+				<img src={provider.faviconUrl} alt="" class="provider-logo" />
+				<div>
+					<p class="eyebrow">Provider</p>
+					<h1 class="text-gradient text-balance">{provider.name}</h1>
+				</div>
+			</div>
+			<p class="subtitle-text text-pretty">
+				{provider.name} punya {provider.totalCount} bansos developer di katalog ini.
+				{provider.activeCount} masih aktif dan bisa dicek cara klaimnya dari halaman detail.
+			</p>
+			<div class="meta-row">
+				<a href={provider.websiteUrl} target="_blank" rel="noopener noreferrer" class="meta-link">
+					<i class="fa-solid fa-arrow-up-right-from-square"></i> Website provider
+				</a>
+				<span><i class="fa-solid fa-circle"></i> {provider.activeCount} aktif</span>
+				<span><i class="fa-solid fa-box-archive"></i> {provider.expiredCount} expired</span>
+			</div>
+			<div class="tag-list">
+				{#each provider.tags as tag (tag)}
+					<span>{tag}</span>
+				{/each}
+			</div>
+		</header>
+
+		<section class="container related-section">
+			<div class="section-header">
+				<h2>Bansos dari {provider.name}</h2>
+				<span>{provider.items.length} item</span>
+			</div>
+			<div class="bansos-grid">
+				{#each provider.items as item (item.id)}
+					<BansosCard {item} />
+				{/each}
+			</div>
+		</section>
+	</main>
+{/if}
+
+<style>
+	.page-wrapper {
+		padding-block: 2.5rem 4rem;
+		display: flex;
+		flex-direction: column;
+		gap: 2rem;
+	}
+
+	.empty-state {
+		margin-block: 3rem;
+		padding: 2rem;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.empty-state p,
+	.subtitle-text {
+		color: var(--text-secondary);
+	}
+
+	.top-nav {
+		display: flex;
+	}
+
+	.btn-back,
+	.meta-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		border: 1px solid var(--border-color);
+		border-radius: 0.65rem;
+		background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+		color: var(--text-secondary);
+		font-weight: 750;
+		padding: 0.55rem 0.85rem;
+	}
+
+	.provider-header {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.provider-identity {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+	}
+
+	.provider-logo {
+		width: 4rem;
+		height: 4rem;
+		border: 1px solid var(--border-color);
+		border-radius: 1rem;
+		background: var(--bg-secondary);
+		object-fit: contain;
+		padding: 0.6rem;
+	}
+
+	.eyebrow {
+		color: var(--color-accent);
+		font-size: 0.8rem;
+		font-weight: 850;
+		text-transform: uppercase;
+	}
+
+	h1 {
+		font-size: clamp(2rem, 1.4rem + 2.4vw, 3.5rem);
+		line-height: 1.08;
+	}
+
+	.subtitle-text {
+		max-width: 48rem;
+		font-size: 1rem;
+	}
+
+	.meta-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		align-items: center;
+	}
+
+	.meta-row span {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		border: 1px solid var(--border-color);
+		border-radius: 999px;
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		font-weight: 750;
+		padding: 0.45rem 0.75rem;
+	}
+
+	.meta-row i {
+		color: var(--color-accent);
+	}
+
+	.tag-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.45rem;
+	}
+
+	.tag-list span {
+		border: 1px solid var(--border-color);
+		border-radius: 0.5rem;
+		color: var(--text-secondary);
+		font-size: 0.78rem;
+		font-weight: 750;
+		padding: 0.25rem 0.6rem;
+	}
+
+	.related-section {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.section-header h2 {
+		font-size: 1.35rem;
+	}
+
+	.section-header span {
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		font-weight: 750;
+	}
+
+	.bansos-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(100%, 20rem), 1fr));
+		gap: 1rem;
+	}
+
+	@media (max-width: 48rem) {
+		.page-wrapper {
+			padding-block: 1.5rem 6rem;
+		}
+
+		.provider-identity {
+			align-items: flex-start;
+		}
+	}
+</style>

--- a/src/routes/providers/[slug]/+page.svelte
+++ b/src/routes/providers/[slug]/+page.svelte
@@ -4,85 +4,69 @@
 
 	let { data } = $props();
 	const provider = $derived(data.provider);
-	const seoTitle = $derived(
-		provider ? `${provider.name} bansos developer - bansos.dev` : 'Provider tidak ditemukan'
-	);
+	const seoTitle = $derived(`${provider.name} bansos developer - bansos.dev`);
 	const seoDescription = $derived(
-		provider
-			? `Daftar bansos developer dari ${provider.name}: ${provider.totalCount} program, ${provider.activeCount} masih aktif, lengkap dengan cara klaim dan link resmi.`
-			: ''
+		`Daftar bansos developer dari ${provider.name}: ${provider.totalCount} program, ${provider.activeCount} masih aktif, lengkap dengan cara klaim dan link resmi.`
 	);
 </script>
 
 <svelte:head>
 	<title>{seoTitle}</title>
-	{#if provider}
-		<meta name="description" content={seoDescription} />
-		<meta property="og:title" content={seoTitle} />
-		<meta property="og:description" content={seoDescription} />
-		<meta property="og:image" content={provider.faviconUrl} />
-		<meta property="twitter:card" content="summary" />
-		<meta property="twitter:title" content={seoTitle} />
-		<meta property="twitter:description" content={seoDescription} />
-		<meta property="twitter:image" content={provider.faviconUrl} />
-	{/if}
+	<meta name="description" content={seoDescription} />
+	<meta property="og:title" content={seoTitle} />
+	<meta property="og:description" content={seoDescription} />
+	<meta property="og:image" content={provider.faviconUrl} />
+	<meta property="twitter:card" content="summary" />
+	<meta property="twitter:title" content={seoTitle} />
+	<meta property="twitter:description" content={seoDescription} />
+	<meta property="twitter:image" content={provider.faviconUrl} />
 </svelte:head>
 
-{#if !provider}
-	<main class="page-wrapper container">
-		<section class="glass-card empty-state">
-			<h1>Provider tidak ditemukan</h1>
-			<p>Provider ini belum punya bansos yang tercatat.</p>
-			<a href={resolve('/providers')} class="btn-primary">Lihat semua provider</a>
-		</section>
-	</main>
-{:else}
-	<main class="page-wrapper">
-		<nav class="container top-nav">
-			<a href={resolve('/providers')} class="btn-back">
-				<i class="fa-solid fa-arrow-left"></i> Semua Provider
+<main class="page-wrapper">
+	<nav class="container top-nav">
+		<a href={resolve('/providers')} class="btn-back">
+			<i class="fa-solid fa-arrow-left"></i> Semua Provider
+		</a>
+	</nav>
+
+	<header class="container provider-header">
+		<div class="provider-identity">
+			<img src={provider.faviconUrl} alt="" class="provider-logo" />
+			<div>
+				<p class="eyebrow">Provider</p>
+				<h1 class="text-gradient text-balance">{provider.name}</h1>
+			</div>
+		</div>
+		<p class="subtitle-text text-pretty">
+			{provider.name} punya {provider.totalCount} bansos developer di katalog ini.
+			{provider.activeCount} masih aktif dan bisa dicek cara klaimnya dari halaman detail.
+		</p>
+		<div class="meta-row">
+			<a href={provider.websiteUrl} target="_blank" rel="noopener noreferrer" class="meta-link">
+				<i class="fa-solid fa-arrow-up-right-from-square"></i> Website provider
 			</a>
-		</nav>
+			<span><i class="fa-solid fa-circle"></i> {provider.activeCount} aktif</span>
+			<span><i class="fa-solid fa-box-archive"></i> {provider.expiredCount} expired</span>
+		</div>
+		<div class="tag-list">
+			{#each provider.tags as tag (tag)}
+				<span>{tag}</span>
+			{/each}
+		</div>
+	</header>
 
-		<header class="container provider-header">
-			<div class="provider-identity">
-				<img src={provider.faviconUrl} alt="" class="provider-logo" />
-				<div>
-					<p class="eyebrow">Provider</p>
-					<h1 class="text-gradient text-balance">{provider.name}</h1>
-				</div>
-			</div>
-			<p class="subtitle-text text-pretty">
-				{provider.name} punya {provider.totalCount} bansos developer di katalog ini.
-				{provider.activeCount} masih aktif dan bisa dicek cara klaimnya dari halaman detail.
-			</p>
-			<div class="meta-row">
-				<a href={provider.websiteUrl} target="_blank" rel="noopener noreferrer" class="meta-link">
-					<i class="fa-solid fa-arrow-up-right-from-square"></i> Website provider
-				</a>
-				<span><i class="fa-solid fa-circle"></i> {provider.activeCount} aktif</span>
-				<span><i class="fa-solid fa-box-archive"></i> {provider.expiredCount} expired</span>
-			</div>
-			<div class="tag-list">
-				{#each provider.tags as tag (tag)}
-					<span>{tag}</span>
-				{/each}
-			</div>
-		</header>
-
-		<section class="container related-section">
-			<div class="section-header">
-				<h2>Bansos dari {provider.name}</h2>
-				<span>{provider.items.length} item</span>
-			</div>
-			<div class="bansos-grid">
-				{#each provider.items as item (item.id)}
-					<BansosCard {item} />
-				{/each}
-			</div>
-		</section>
-	</main>
-{/if}
+	<section class="container related-section">
+		<div class="section-header">
+			<h2>Bansos dari {provider.name}</h2>
+			<span>{provider.items.length} item</span>
+		</div>
+		<div class="bansos-grid">
+			{#each provider.items as item (item.id)}
+				<BansosCard {item} />
+			{/each}
+		</div>
+	</section>
+</main>
 
 <style>
 	.page-wrapper {
@@ -92,16 +76,6 @@
 		gap: 2rem;
 	}
 
-	.empty-state {
-		margin-block: 3rem;
-		padding: 2rem;
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 1rem;
-	}
-
-	.empty-state p,
 	.subtitle-text {
 		color: var(--text-secondary);
 	}

--- a/src/routes/providers/[slug]/+page.ts
+++ b/src/routes/providers/[slug]/+page.ts
@@ -1,3 +1,4 @@
+import { error } from '@sveltejs/kit';
 import { getProviderStats } from '$lib/data/bansos';
 import type { EntryGenerator } from './$types';
 
@@ -8,8 +9,12 @@ export const entries: EntryGenerator = () => {
 export function load({ params }) {
 	const provider = getProviderStats().find((entry) => entry.slug === params.slug);
 
+	if (!provider) {
+		error(404, 'Provider tidak ditemukan');
+	}
+
 	return {
-		provider: provider || null,
+		provider,
 		slug: params.slug
 	};
 }

--- a/src/routes/providers/[slug]/+page.ts
+++ b/src/routes/providers/[slug]/+page.ts
@@ -1,0 +1,15 @@
+import { getProviderStats } from '$lib/data/bansos';
+import type { EntryGenerator } from './$types';
+
+export const entries: EntryGenerator = () => {
+	return getProviderStats().map((provider) => ({ slug: provider.slug }));
+};
+
+export function load({ params }) {
+	const provider = getProviderStats().find((entry) => entry.slug === params.slug);
+
+	return {
+		provider: provider || null,
+		slug: params.slug
+	};
+}

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,6 +1,6 @@
 export const prerender = true;
 
-import { bansosList } from '$lib/data/bansos';
+import { bansosList, getProviderStats } from '$lib/data/bansos';
 
 export async function GET() {
 	const today = new Date().toISOString().split('T')[0];
@@ -30,6 +30,12 @@ export async function GET() {
     <lastmod>${today}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://bansos.dev/providers/</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>`;
 
 	bansosList.forEach((item) => {
@@ -39,6 +45,16 @@ export async function GET() {
     <lastmod>${today}</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
+  </url>`;
+	});
+
+	getProviderStats().forEach((provider) => {
+		sitemap += `
+  <url>
+    <loc>https://bansos.dev/providers/${provider.slug}/</loc>
+    <lastmod>${today}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>`;
 	});
 


### PR DESCRIPTION
## Summary
- Add auto-generated provider listing page at `/providers` and detail pages at `/providers/[slug]`.
- Link provider names from bansos cards/detail pages to provider pages when the static provider page exists.
- Add Provider nav item and include provider pages in `sitemap.xml`.
- Add pagination and free-text search to `/list`.
- Add provider favicon, source metadata, and auto-generated commit contributors to bansos detail pages.
- Add commit contributor labeling on home and a commit contributor list/explanation on `/contribute`.
- Polish list/detail mobile spacing, improve the detail back button, and add the community homepage tagline.

## Auto-maintenance notes
- Provider slugs, counts, status totals, tags, and related bansos lists are derived from `bansosList`.
- No manual provider data file is required for new bansos entries.
- Provider favicon falls back to Google favicon lookup based on the official CTA domain, or `providerLogoUrl` when present in data.
- `source` is optional in data and falls back to the item CTA link when absent.
- Commit contributors are generated from git history for `src/lib/data/bansos.json` via `npm run generate:commit-contributors`.
- Pagination/search are presentation-only and do not change the `bansosdev` CLI payload or package behavior.

## Validation
- `npm run check`
- `npm run build`
- `curl -I http://127.0.0.1:5173/providers/`
- `curl -I http://127.0.0.1:5173/providers/microsoft/`
- Browser smoke check: provider pages, detail metadata, `/list` search, pagination, and `/contribute` commit contributor section with no mobile horizontal overflow.
