### PR TITLE
[codex] migrate deploy to GitHub Pages

### DIFF
--- a/.github/workflows/add-bansos.yml
+++ b/.github/workflows/add-bansos.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   add:
@@ -34,16 +35,35 @@ jobs:
 
       - run: npm run build
 
-      - name: Commit changes
+      - name: Create pull request
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BANSOS_PAYLOAD: ${{ inputs.payload }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/lib/data/bansos.json src/lib/data/commit-contributors.json
-          git commit -m "feat: add bansos from CLI"
-          git push
 
-      - name: Deploy to Cloudflare Pages
-        run: npx wrangler pages deploy build --project-name bansos --branch main
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          item_id="$(node -e 'const payload = JSON.parse(process.env.BANSOS_PAYLOAD); console.log(payload.id)')"
+          item_title="$(node -e 'const payload = JSON.parse(process.env.BANSOS_PAYLOAD); console.log(payload.title)')"
+          branch="bansos/direct-${{ github.run_id }}-${item_id}"
+
+          git switch -c "$branch"
+          git add src/lib/data/bansos.json src/lib/data/commit-contributors.json
+          git commit -m "feat: add ${item_title}"
+          git push --force origin "$branch"
+
+          pr_url="$(
+            gh pr create \
+              --title "Tambah bansos: ${item_title}" \
+              --body "Auto-generated from maintainer direct mode.
+
+          ## Summary
+          - Add ${item_title} to the bansos list.
+          - Source payload comes from trusted maintainer direct mode.
+
+          This PR keeps main branch changes behind review and GitHub Pages deployment." \
+              --base main \
+              --head "$branch"
+          )"
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,46 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v4
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![npm bansosdev](https://img.shields.io/npm/v/bansosdev?label=bansosdev&color=10b981)](https://www.npmjs.com/package/bansosdev)
 [![License: MIT](https://img.shields.io/badge/License-MIT-10b981.svg)](LICENSE)
 [![Built with SvelteKit](https://img.shields.io/badge/Built%20with-SvelteKit-ff3e00)](https://kit.svelte.dev/)
-[![Deploy: Cloudflare Pages](https://img.shields.io/badge/Deploy-Cloudflare%20Pages-f38020)](https://pages.cloudflare.com/)
+[![Deploy: GitHub Pages](https://img.shields.io/badge/Deploy-GitHub%20Pages-181717)](https://pages.github.com/)
 
 `Bantuan sosial untuk developer jelata`
 
@@ -34,7 +34,7 @@ Situs ini dibangun sebagai static SvelteKit site yang SEO-friendly, data-driven,
 - [SvelteKit](https://kit.svelte.dev/) static site
 - [TypeScript](https://www.typescriptlang.org/)
 - [Vite](https://vite.dev/)
-- [Cloudflare Pages](https://pages.cloudflare.com/)
+- [GitHub Pages](https://pages.github.com/)
 - GitHub Actions untuk CI dan workflow kontribusi data
 - `bansosdev` CLI untuk submit listing baru
 
@@ -137,7 +137,7 @@ Jika punya token maintainer, gunakan mode direct:
 BANSOSDEV_GITHUB_TOKEN=ghp_xxx npx bansosdev add ... --mode direct
 ```
 
-Token perlu punya akses repository yang cukup untuk membuat perubahan data dan memicu workflow.
+Token perlu punya akses repository yang cukup untuk memicu workflow. Mode ini membuat Pull Request otomatis; merge ke `main` akan memicu deploy GitHub Pages.
 
 Detail lengkap CLI lihat [docs/bansosdev-cli.md](docs/bansosdev-cli.md).
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Situs ini dibangun sebagai static SvelteKit site yang SEO-friendly, data-driven,
 - GitHub Actions untuk CI dan workflow kontribusi data
 - `bansosdev` CLI untuk submit listing baru
 
+## Deploy dan domain
+
+Deploy produksi berjalan lewat GitHub Pages dari workflow `.github/workflows/deploy-pages.yml`.
+Repository ini tidak membutuhkan token Cloudflare untuk deploy.
+
+Jika memakai Cloudflare sebagai DNS untuk custom domain, arahkan DNS ke GitHub Pages dan gunakan mode DNS only sampai verifikasi domain dan sertifikat HTTPS GitHub Pages aktif.
+Jangan menyimpan `CLOUDFLARE_API_TOKEN` atau `CLOUDFLARE_ACCOUNT_ID` di GitHub Actions secrets untuk deploy situs ini.
+
 ## Menjalankan proyek
 
 ```bash

--- a/docs/bansosdev-cli.md
+++ b/docs/bansosdev-cli.md
@@ -6,7 +6,7 @@
 
 - Mode default: `issue`.
   CLI menghasilkan URL GitHub Issue dengan payload JSON. Issue yang valid akan dibuatkan Pull Request otomatis oleh GitHub Actions.
-- `--mode direct`: maintainer trigger `workflow_dispatch` ke repo.
+- `--mode direct`: maintainer trigger `workflow_dispatch` ke repo untuk membuat Pull Request otomatis.
 - `--mode json`: cetak payload JSON saja (untuk validasi).
 
 ## Contributor (tanpa token)
@@ -51,7 +51,7 @@ BANSOSDEV_GITHUB_TOKEN=ghp_xxx npx bansosdev add \
 Token GitHub untuk `--mode direct`:
 
 - Repo scope: `wauputr4/bansos`
-- Permission minimum: `Contents: write`, `Workflows: write`.
+- Permission minimum: `Contents: write`, `Pull requests: write`, `Workflows: write`.
 - Simpan di environment lokal / CI secret sebagai `BANSOSDEV_GITHUB_TOKEN`.
 
 Contoh lengkap dengan validasi:

--- a/docs/bansosdev-cli.md
+++ b/docs/bansosdev-cli.md
@@ -51,7 +51,7 @@ BANSOSDEV_GITHUB_TOKEN=ghp_xxx npx bansosdev add \
 Token GitHub untuk `--mode direct`:
 
 - Repo scope: `wauputr4/bansos`
-- Permission minimum: `Contents: write`, `Pull requests: write`, `Workflows: write`.
+- Permission minimum: `contents: write`, `pull-requests: write`, `workflows: write`.
 - Simpan di environment lokal / CI secret sebagai `BANSOSDEV_GITHUB_TOKEN`.
 
 Contoh lengkap dengan validasi:

--- a/packages/bansosdev-cli/README.md
+++ b/packages/bansosdev-cli/README.md
@@ -55,9 +55,10 @@ workflow repo akan mencoba membuat Pull Request otomatis dari payload tersebut.
 BANSOSDEV_GITHUB_TOKEN=ghp_xxx npx bansosdev add ... --mode direct
 ```
 
-Mode direct memerlukan token dengan permission minimal:
+Mode direct membuat Pull Request otomatis dan memerlukan token dengan permission minimal:
 
 - `contents: write`
+- `pull-requests: write`
 - `workflows: write`
 
 ## Optional


### PR DESCRIPTION
## Summary
- replace the Cloudflare Pages deploy step with a GitHub Pages Actions workflow
- make maintainer direct submissions create PRs instead of pushing straight to main
- update docs and badges from Cloudflare Pages to GitHub Pages

## Security impact
- removes all tracked workflow references to CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN
- keeps deploys behind main merges so branch protection can block direct pushes safely

## After merge
- enable GitHub Pages with source: GitHub Actions
- remove CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN from repository Actions secrets
- protect main with required PR review and no direct pushes
- point Cloudflare DNS to the GitHub Pages hostname/custom domain once Pages is live

## Validation
- ruby YAML parse for .github/workflows/*.yml
- npm run check
- npm run build
- npx prettier --check on touched files

Note: npm run lint still fails on pre-existing Prettier drift in five unrelated files: scripts/generate-commit-contributors.mjs, src/lib/components/GithubBadge.svelte, src/lib/components/SiteShell.svelte, src/routes/about/+page.svelte, and src/routes/contribute/+page.svelte.