### PR TITLE
fix: sanitize URLs to prevent XSS vulnerabilities

### DIFF
--- a/packages/bansosdev-cli/bin/bansosdev.mjs
+++ b/packages/bansosdev-cli/bin/bansosdev.mjs
@@ -81,9 +81,16 @@ function csv(value) {
 
 function validateUrl(value, key) {
 	try {
-		return new URL(value).toString();
-	} catch {
-		throw new Error(`--${key} must be a valid URL`);
+		const parsed = new URL(value);
+		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+			throw new Error('protocol');
+		}
+		return parsed.toString();
+	} catch (error) {
+		if (error.message === 'protocol') {
+			throw new Error(`--${key} must use http: or https: protocol`, { cause: error });
+		}
+		throw new Error(`--${key} must be a valid URL`, { cause: error });
 	}
 }
 

--- a/packages/bansosdev-cli/bin/bansosdev.mjs
+++ b/packages/bansosdev-cli/bin/bansosdev.mjs
@@ -80,18 +80,18 @@ function csv(value) {
 }
 
 function validateUrl(value, key) {
+	let parsed;
 	try {
-		const parsed = new URL(value);
-		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-			throw new Error('protocol');
-		}
-		return parsed.toString();
+		parsed = new URL(value);
 	} catch (error) {
-		if (error.message === 'protocol') {
-			throw new Error(`--${key} must use http: or https: protocol`, { cause: error });
-		}
 		throw new Error(`--${key} must be a valid URL`, { cause: error });
 	}
+
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+		throw new Error(`--${key} must use http: or https: protocol`);
+	}
+
+	return parsed.toString();
 }
 
 function isValidCalendarDate(value) {

--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -60,9 +60,24 @@ const DEFAULT_UTM = {
 	campaign: 'bansos'
 };
 
-function appendDefaultUtmParams(url: string) {
+export function sanitizeUrl(url: string, fallback = '#') {
 	try {
 		const parsed = new URL(url);
+		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+			return fallback;
+		}
+		return parsed.toString();
+	} catch {
+		return fallback;
+	}
+}
+
+function appendDefaultUtmParams(url: string) {
+	const safeUrl = sanitizeUrl(url);
+	if (safeUrl === '#') return safeUrl;
+
+	try {
+		const parsed = new URL(safeUrl);
 		if (!parsed.searchParams.has('utm_source')) {
 			parsed.searchParams.set('utm_source', DEFAULT_UTM.source);
 		}
@@ -74,15 +89,24 @@ function appendDefaultUtmParams(url: string) {
 		}
 		return parsed.toString();
 	} catch {
-		return url;
+		return safeUrl;
 	}
 }
 
-export function addTrackedCtaLink(item: BansosItem): BansosItem {
-	return {
+export function sanitizeAndTrackBansosItem(item: BansosItem): BansosItem {
+	const sanitizedItem = {
 		...item,
 		ctaLink: appendDefaultUtmParams(item.ctaLink)
 	};
+
+	if (sanitizedItem.contributor?.url) {
+		sanitizedItem.contributor = {
+			...sanitizedItem.contributor,
+			url: sanitizeUrl(sanitizedItem.contributor.url)
+		};
+	}
+
+	return sanitizedItem;
 }
 
 export function normalizeBansosStatuses(items: BansosItem[], referenceDate = new Date()) {
@@ -105,7 +129,7 @@ export function normalizeBansosStatuses(items: BansosItem[], referenceDate = new
 }
 
 export const bansosList: BansosItem[] = normalizeBansosStatuses(
-	(bansosData as BansosItem[]).map((item) => addTrackedCtaLink(item))
+	(bansosData as BansosItem[]).map((item) => sanitizeAndTrackBansosItem(item))
 );
 
 function itemDateValue(item: BansosItem, fallbackIndex: number) {
@@ -212,15 +236,17 @@ function providerKey(provider: string) {
 function providerWebsiteFrom(item: BansosItem) {
 	try {
 		const parsed = new URL(item.ctaLink);
+		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '#';
 		return parsed.origin;
 	} catch {
-		return item.ctaLink;
+		return '#';
 	}
 }
 
 function faviconUrlFor(url: string) {
 	try {
 		const parsed = new URL(url);
+		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '';
 		return `https://www.google.com/s2/favicons?domain=${parsed.hostname}&sz=128`;
 	} catch {
 		return '';
@@ -294,9 +320,10 @@ function contributorKey(name: string, url: string) {
 function normalizeContributorUrl(url: string) {
 	try {
 		const parsed = new URL(url.trim());
+		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '#';
 		return `${parsed.origin}${parsed.pathname.replace(/\/+$/, '')}${parsed.search}${parsed.hash}`;
 	} catch {
-		return url.trim().replace(/\/+$/, '');
+		return '#';
 	}
 }
 

--- a/src/lib/data/bansos.ts
+++ b/src/lib/data/bansos.ts
@@ -60,16 +60,21 @@ const DEFAULT_UTM = {
 	campaign: 'bansos'
 };
 
-export function sanitizeUrl(url: string, fallback = '#') {
+function parseAndValidateUrl(url: string): URL | null {
 	try {
-		const parsed = new URL(url);
+		const parsed = new URL(url.trim());
 		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-			return fallback;
+			return null;
 		}
-		return parsed.toString();
+		return parsed;
 	} catch {
-		return fallback;
+		return null;
 	}
+}
+
+export function sanitizeUrl(url: string, fallback = '#') {
+	const parsed = parseAndValidateUrl(url);
+	return parsed ? parsed.toString() : fallback;
 }
 
 function appendDefaultUtmParams(url: string) {
@@ -234,23 +239,13 @@ function providerKey(provider: string) {
 }
 
 function providerWebsiteFrom(item: BansosItem) {
-	try {
-		const parsed = new URL(item.ctaLink);
-		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '#';
-		return parsed.origin;
-	} catch {
-		return '#';
-	}
+	const parsed = parseAndValidateUrl(item.ctaLink);
+	return parsed ? parsed.origin : '#';
 }
 
 function faviconUrlFor(url: string) {
-	try {
-		const parsed = new URL(url);
-		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '';
-		return `https://www.google.com/s2/favicons?domain=${parsed.hostname}&sz=128`;
-	} catch {
-		return '';
-	}
+	const parsed = parseAndValidateUrl(url);
+	return parsed ? `https://www.google.com/s2/favicons?domain=${parsed.hostname}&sz=128` : '';
 }
 
 let cachedProviderStats: ProviderSummary[] | null = null;
@@ -318,13 +313,9 @@ function contributorKey(name: string, url: string) {
 }
 
 function normalizeContributorUrl(url: string) {
-	try {
-		const parsed = new URL(url.trim());
-		if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return '#';
-		return `${parsed.origin}${parsed.pathname.replace(/\/+$/, '')}${parsed.search}${parsed.hash}`;
-	} catch {
-		return '#';
-	}
+	const parsed = parseAndValidateUrl(url);
+	if (!parsed) return '#';
+	return `${parsed.origin}${parsed.pathname.replace(/\/+$/, '')}${parsed.search}${parsed.hash}`;
 }
 
 export function getContributorStats() {


### PR DESCRIPTION
# Ringkasan

Sebelum perbaikan ini, nilai `ctaLink` dan `contributor.url` hanya divalidasi menggunakan konstruktor `URL`, yang masih mengizinkan skema berbahaya seperti `javascript:`. Akibatnya, payload JavaScript dapat tersimpan di data dan dieksekusi ketika pengguna mengklik tautan yang dirender oleh aplikasi.


## Kerentanan

### Sebelum Perbaikan

Parameter berikut pada CLI:

* `--cta-link`
* `--contributor-url`

hanya diperiksa menggunakan konstruktor `URL`.

Karena URL seperti berikut dianggap valid secara sintaksis:

```text
javascript:alert('XSS')
```

penyerang dapat menyisipkan payload ke dalam data yang kemudian dirender langsung ke atribut `href` pada frontend.

Contoh payload:

```json
{
  "ctaLink": "javascript:alert('XSS Payload Executed')"
}
```

Ketika pengguna mengklik tautan tersebut, kode JavaScript akan dijalankan dalam konteks domain aplikasi.

## Perbaikan

### 1. Validasi URL pada CLI

**File:**

* `bansosdev.mjs`

Fungsi `validateUrl()` diperketat untuk hanya menerima protokol:

* `http:`
* `https:`

URL dengan protokol lain akan langsung ditolak, termasuk:

* `javascript:`
* `data:`
* `vbscript:`

Dengan perubahan ini, payload berbahaya tidak dapat masuk melalui jalur kontribusi normal.

---

### 2. Sanitasi URL pada Lapisan Data

**File:**

* `src/lib/bansos.ts`

Sebagai lapisan perlindungan tambahan, utilitas `sanitizeUrl()` ditambahkan ke proses hidrasi data melalui `sanitizeAndTrackBansosItem()`.

Setiap URL akan:

1. Diparsing ulang.
2. Diverifikasi protokolnya.
3. Diganti menjadi `#` apabila tidak valid atau menggunakan protokol yang tidak diizinkan.

Pendekatan ini memastikan bahwa perubahan manual pada `bansos.json` tetap tidak dapat digunakan untuk menyisipkan payload XSS.

## Cakupan Perlindungan

Perbaikan ini mencakup seluruh atribut `href` yang berasal dari data kontribusi pengguna:

### Terlindungi

* `ctaLink`
* `contributor.url`

### Tidak Memerlukan Perubahan

* `item.source`

Field ini sudah memiliki validasi eksplisit pada frontend dan hanya dirender sebagai tautan apabila diawali dengan:

```text
http://
https://
```

## Pertimbangan Implementasi

### URL Relatif

URL relatif seperti:

```text
/path
```

secara sengaja tidak didukung.

Karena `URL` membutuhkan URL absolut, nilai tersebut akan dianggap tidak valid dan otomatis disanitasi menjadi:

```text
#
```

Perilaku ini sesuai dengan kebutuhan aplikasi karena tautan promosi dan profil kontributor memang harus menggunakan URL eksternal yang lengkap.

### Kinerja

Sanitasi dilakukan pada tahap pemrosesan data, bukan saat rendering komponen. Dengan demikian tidak ada overhead tambahan pada interaksi pengguna maupun proses navigasi halaman.

## Validasi

* Payload dengan skema `javascript:` berhasil diblokir pada CLI.
* Payload yang melewati CLI tetap disanitasi pada lapisan data.
* Seluruh atribut `href` yang berasal dari data kontribusi pengguna telah tercakup.
* Tidak ditemukan jalur bypass yang diketahui melalui data bansos saat ini.

## Dampak

Perbaikan ini menghilangkan vektor Stored XSS dengan risiko tertinggi pada repository yang menerima konten dari kontributor eksternal.
Maintainer tidak lagi perlu melakukan verifikasi manual terhadap setiap URL yang dikirimkan untuk memastikan tidak mengandung payload JavaScript berbahaya, karena validasi dan sanitasi kini dilakukan secara otomatis oleh sistem.