### PR TITLE
Tambah bansos: GLM-5.2 gratis 5 hari di ZCode

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -596,6 +596,6 @@
 		"tags": ["AI", "Coding", "Gratisan", "GLM", "Z.ai"],
 		"featured": false,
 		"status": "active",
-		"src": "https://zcode.z.ai/en/changelog"
+		"source": "https://zcode.z.ai/en/changelog"
 	}
 ]

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -563,5 +563,39 @@
 		"tags": ["AI Credits", "Model API", "Gratisan"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "zcode-glm-52-free",
+		"title": "GLM-5.2 Gratis 5 Hari di ZCode",
+		"provider": "ZCode",
+		"description": "ZCode menyediakan GLM Start Plan untuk pengguna baru, berisi akses 5 hari berturut-turut ke model flagship GLM. Cocok untuk mencoba GLM-5.2 untuk coding agent, debugging, refactor, dan pengerjaan proyek besar.",
+		"benefits": [
+			"Gratis 5 hari untuk pengguna baru",
+			"Akses GLM flagship model",
+			"Bisa mencoba GLM-5.2 jika tersedia di akun ZCode",
+			"Cocok untuk coding agent dan long-horizon task",
+			"Kuota 150% di aplikasi untuk pengguna GLM Coding Plan"
+		],
+		"validity": {
+			"type": "uncertain",
+			"description": "Promo tersedia sejak rilis ZCode 3.0.0 dan dapat berubah sewaktu-waktu"
+		},
+		"requirements": [
+			"Download ZCode",
+			"Buat atau login akun Z.ai",
+			"Aktifkan GLM Start Plan",
+			"Pilih model GLM-5.2 jika tersedia",
+			"Gunakan lewat aplikasi ZCode"
+		],
+		"publishedAt": "2026-06-14",
+		"contributor": {
+			"name": "Aofsnorth",
+			"url": "https://github.com/Aofsnorth"
+		},
+		"ctaLink": "https://zcode.z.ai/en",
+		"tags": ["AI", "Coding", "Gratisan", "GLM", "Z.ai"],
+		"featured": false,
+		"status": "active",
+		"src": "https://zcode.z.ai/en/changelog"
 	}
 ]

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -186,5 +186,13 @@
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
+	],
+	"zcode-glm-52-free": [
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=wauputr4"
+		}
 	]
 }


### PR DESCRIPTION
## Summary
- Add ZCode GLM Start Plan listing from issue #30.
- Credit issue contributor Aofsnorth in the listing metadata.
- Use official ZCode changelog as source evidence for the 5-day GLM flagship access and 150% app quota note.

## Source
- https://zcode.z.ai/en/changelog

## Verification
- npm run lint
- npm run check
- npm run build

Closes #30