### PR TITLE
fix: restore commit contributors lost in merge

### DIFF
--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -5,30 +5,36 @@
 			"name": "Aofsnorth",
 			"avatarUrl": "https://github.com/Aofsnorth.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Aofsnorth"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8105e48b0a6e5449d1fff3829b5968b02d84cdca4"
 		}
 	],
 	"aiclass-asean-courses": [
 		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/d5f8f7a6164d424d409980a9bf0121576077acb6"
 		}
 	],
 	"amd-ai-dev-program": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
 	"aws-activate-credits": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
 	"dahono-labs-ai-api": [
@@ -36,143 +42,179 @@
 			"login": "wauputr4",
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/52f2a90e047f8cb2c31851f55e0e40b989ac9eb6"
 		}
 	],
 	"deepseek-free-token": [
 		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
 	"digitalocean-hatch": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
 	"google-startups-cloud": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
 	"idwebhost-domain-gratis-1tahun": [
 		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e88f4b9151a8ad412aebefcb64a783f6437cb349"
 		}
 	],
 	"inceptionlabs-get-started": [
 		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
 	"kie-ai-api-discount-credit": [
 		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
 	"kimchi-dev-serverless-ai": [
 		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
 	"microsoft-founders-hub": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
 	"mongodb-startups": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
 	"namecheap-hosting-trial": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/f264304560e07b2e7e58b1e37915227d2b1ee21a"
 		}
 	],
 	"namecheap-vps-hosting": [
 		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e88f4b9151a8ad412aebefcb64a783f6437cb349"
 		}
 	],
 	"namecom-domain-app": [
 		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/a53c64cdefcae865d843ec6b05fff598b03ccfee"
 		}
 	],
 	"notion-ai-unlimited-1-bulan": [
 		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/b82404464f3ef8662aa1736ab35d173f3b45eefd"
 		}
 	],
 	"qoder-qwen-max-free": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/b2c52d151481cf939939b2cd211a6c6f69f3507d"
 		}
 	],
 	"tokenrouter-minimax-m3-free": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8389c12d14e04ae8109e74f705084e7443bd987f"
 		}
 	],
 	"tokenrouter-model-gateway": [
 		{
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/772f271ea2d27cd1b0d687cec951f7cee54c4d9d"
+		},
+		{
 			"login": "wauputr4",
-			"name": "Wauputra",
+			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
 	"xai-grok-api-credits": [
 		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"login": "Renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
 	"zcode-glm-52-free": [
@@ -180,7 +222,7 @@
 			"login": "wauputr4",
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/8fe126b0a6e5449d1fff3829b5968b02d84cdca4"
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/692fa746e0322d388932fdcfd8a28992267ff15a"
 		}
 	]
 }

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -16,7 +16,7 @@
 	"aiclass-asean-courses": [
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/d5f8f7a6164d424d409980a9bf0121576077acb6"
 		}
@@ -54,7 +54,7 @@
 		},
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
@@ -78,7 +78,7 @@
 	"idwebhost-domain-gratis-1tahun": [
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e88f4b9151a8ad412aebefcb64a783f6437cb349"
 		}
@@ -92,7 +92,7 @@
 		},
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
@@ -106,7 +106,7 @@
 		},
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
@@ -120,7 +120,7 @@
 		},
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
@@ -152,7 +152,7 @@
 	"namecheap-vps-hosting": [
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e88f4b9151a8ad412aebefcb64a783f6437cb349"
 		}
@@ -166,7 +166,7 @@
 		},
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/a53c64cdefcae865d843ec6b05fff598b03ccfee"
 		}
@@ -174,7 +174,7 @@
 	"notion-ai-unlimited-1-bulan": [
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/b82404464f3ef8662aa1736ab35d173f3b45eefd"
 		}
@@ -204,7 +204,7 @@
 		},
 		{
 			"login": "wauputr4",
-			"name": "wauputr4",
+			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}


### PR DESCRIPTION
## Ringkas
Commit contributors (`commit-contributors.json") ke-replace jadi `wauputr4` semua pas merge PR #36 karena `generate-commit-contributors.mjs` jalan di konteks branch PR, bukan `main`.

**Akar masalah:** Script liat git log dari branch PR yang nggak punya full history `main`, jadi kontribusi Renzie2161 dkk hilang.

## Perbaikan
- Restore `commit-contributors.json` dari state sebelum merge (commit `8fe126b`)
- Tambah entry `aerolink-free-credits` dengan Aofsnorth + wauputr4
- Format dengan Prettier

## Validasi
- CI akan jalan setelah PR dibuat
- 23 entries, Renzie2161 balik ke 14 entries, Aofsnorth masuk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refreshed contributor attribution across multiple credit programs by updating contributor identity details and reference links.
  * Expanded contributor listings for several programs to improve coverage and accuracy.
  * Updated contributor metadata and URLs throughout the credits database to keep attributions reliable and up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->