### PR TITLE
fix: issue-to-pr auth uses maintainer token

### DIFF
--- a/.github/workflows/add-bansos.yml
+++ b/.github/workflows/add-bansos.yml
@@ -12,6 +12,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  GITHUB_ACTION_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
+
 jobs:
   add:
     runs-on: ubuntu-latest
@@ -38,7 +41,7 @@ jobs:
       - name: Create pull request
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ env.GITHUB_ACTION_TOKEN }}
           BANSOS_PAYLOAD: ${{ inputs.payload }}
         run: |
           git config user.name "github-actions[bot]"
@@ -49,6 +52,7 @@ jobs:
           branch="bansos/direct-${{ github.run_id }}-${item_id}"
 
           git switch -c "$branch"
+          git remote set-url origin https://x-access-token:${GITHUB_ACTION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           git add src/lib/data/bansos.json src/lib/data/commit-contributors.json
           git commit -m "feat: add ${item_title}"
           git push --force origin "$branch"

--- a/.github/workflows/add-bansos.yml
+++ b/.github/workflows/add-bansos.yml
@@ -12,9 +12,6 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  GITHUB_ACTION_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
-
 jobs:
   add:
     runs-on: ubuntu-latest
@@ -41,8 +38,9 @@ jobs:
       - name: Create pull request
         id: pr
         env:
-          GH_TOKEN: ${{ env.GITHUB_ACTION_TOKEN }}
+          GH_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
           BANSOS_PAYLOAD: ${{ inputs.payload }}
+          AUTH_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -52,7 +50,7 @@ jobs:
           branch="bansos/direct-${{ github.run_id }}-${item_id}"
 
           git switch -c "$branch"
-          git remote set-url origin https://x-access-token:${GITHUB_ACTION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://x-access-token:${AUTH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           git add src/lib/data/bansos.json src/lib/data/commit-contributors.json
           git commit -m "feat: add ${item_title}"
           git push --force origin "$branch"

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -9,9 +9,6 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  GITHUB_ACTION_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
-
 jobs:
   create-pr:
     if: ${{ contains(github.event.issue.labels.*.name, 'submission') || startsWith(github.event.issue.title, 'Tambah bansos:') }}
@@ -20,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: true
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -48,13 +45,15 @@ jobs:
         run: npm run build
 
       - name: Setup git auth
+        env:
+          AUTH_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
         run: |
-          git remote set-url origin https://x-access-token:${GITHUB_ACTION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git remote set-url origin https://x-access-token:${AUTH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
       - name: Create pull request
         id: pr
         env:
-          GH_TOKEN: ${{ env.GITHUB_ACTION_TOKEN }}
+          GH_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ITEM_ID: ${{ steps.payload.outputs.id }}
           ITEM_TITLE: ${{ steps.payload.outputs.title }}
@@ -104,9 +103,23 @@ jobs:
       - name: Auto-approve PR
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.BANSOS_PAT }}
+          GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ steps.pr.outputs.url }}
-        run: gh pr review "$PR_URL" --approve
+        run: |
+          if [ -z "${PR_URL:-}" ]; then
+            echo "No PR URL, skipping auto-approve."
+            exit 0
+          fi
+
+          PR_AUTHOR="$(gh pr view "$PR_URL" --json author --jq '.author.login')"
+          REVIEWER="$(gh api user -q .login)"
+
+          if [ "$PR_AUTHOR" = "$REVIEWER" ]; then
+            echo "Skip auto-approve: PR author and reviewer are the same user ($REVIEWER)."
+            exit 0
+          fi
+
+          gh pr review "$PR_URL" --approve
 
       - name: Comment on issue
         env:

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -9,6 +9,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  GITHUB_ACTION_TOKEN: ${{ secrets.BANSOS_PAT || github.token }}
+
 jobs:
   create-pr:
     if: ${{ contains(github.event.issue.labels.*.name, 'submission') || startsWith(github.event.issue.title, 'Tambah bansos:') }}
@@ -17,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - uses: actions/setup-node@v4
         with:
@@ -44,10 +47,14 @@ jobs:
       - name: Build site
         run: npm run build
 
+      - name: Setup git auth
+        run: |
+          git remote set-url origin https://x-access-token:${GITHUB_ACTION_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+
       - name: Create pull request
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ env.GITHUB_ACTION_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ITEM_ID: ${{ steps.payload.outputs.id }}
           ITEM_TITLE: ${{ steps.payload.outputs.title }}


### PR DESCRIPTION
Perbaiki workflow agar Issue-to-PR dapat push dan membuat PR dengan auth yang cukup.

- Issue-to-PR workflow: persist-credentials true + set remote origin via token.
- Gunakan token terpusat `GITHUB_ACTION_TOKEN = BANSOS_PAT || github.token` untuk git push dan `gh pr create`.
- Add-bansos workflow juga memakai token ini agar mode direct tidak gagal karena permission.

Dengan ini kita mengurangi failure:
- `fatal: could not read Username for 'https://github.com': No such device or address`
- `GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved authentication for automated pull-request creation and issue-to-pull-request workflows, including safer token handling with a configurable fallback and updating the remote push URL.
  * Enhanced auto-approval behavior by adding safeguards to avoid approving when required inputs are missing or when the author and reviewer match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->