### PR TITLE
fix: fetch full history for direct contributor generation

### DIFF
--- a/.github/workflows/add-bansos.yml
+++ b/.github/workflows/add-bansos.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- Add full-history checkout in .github/workflows/add-bansos.yml for direct mode workflow.
- Prevent commit-contributors.json being regenerated with truncated contributor history when workflow runs from shallow checkout.
- Keeps contributor history per item stable and avoids replacement-like behavior after npx direct mode tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration configuration to ensure complete repository history is available during build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->