### PR TITLE
fix: add duplicate ID validation in form

### DIFF
--- a/src/lib/components/BansosForm.svelte
+++ b/src/lib/components/BansosForm.svelte
@@ -55,17 +55,27 @@
 			.replace(/^-+|-+$/g, '');
 	}
 
+	function generateUniqueId(baseSlug: string): string {
+		let slug = baseSlug;
+		let counter = 1;
+		while (existingIds.has(slug)) {
+			slug = `${baseSlug}-${counter}`;
+			counter++;
+		}
+		return slug;
+	}
+
 	$effect(() => {
 		if (formTitle && !formId) {
 			const slug = slugify(formTitle);
-			if (!existingIds.has(slug)) {
-				formId = slug;
+			if (slug) {
+				formId = generateUniqueId(slug);
 			}
 		}
 	});
 
 	function fillExample(item: (typeof bansosList)[number]) {
-		formId = item.id;
+		formId = '';
 		formTitle = item.title;
 		formProvider = item.provider;
 		formDescription = item.description;

--- a/src/lib/components/BansosForm.svelte
+++ b/src/lib/components/BansosForm.svelte
@@ -7,6 +7,7 @@
 	const existingTags = [...new Set(bansosList.flatMap((i) => i.tags))].sort((a, b) =>
 		a.localeCompare(b)
 	);
+	const existingIds = new Set(bansosList.map((i) => i.id));
 
 	const examples = bansosList.filter((i) => i.status === 'active').slice(0, 3);
 
@@ -56,7 +57,10 @@
 
 	$effect(() => {
 		if (formTitle && !formId) {
-			formId = slugify(formTitle);
+			const slug = slugify(formTitle);
+			if (!existingIds.has(slug)) {
+				formId = slug;
+			}
 		}
 	});
 
@@ -136,6 +140,8 @@
 		if (!formId.trim()) errors.push('ID wajib diisi');
 		else if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(formId.trim()))
 			errors.push('ID harus kebab-case lowercase (contoh: nama-bansos)');
+		else if (existingIds.has(formId.trim()))
+			errors.push('ID sudah ada di katalog. Gunakan ID yang berbeda.');
 
 		if (!formTitle.trim()) errors.push('Title wajib diisi');
 		if (!formProvider.trim()) errors.push('Provider wajib diisi');


### PR DESCRIPTION
## Summary
- Add client-side duplicate ID check before form submission
- Show error message 'ID sudah ada di katalog. Gunakan ID yang berbeda.' when ID exists
- Auto-generate ID only if slugified title doesn't conflict with existing IDs
- Prevents GitHub Action from failing with duplicate ID error

## Context
Issue #60 submitted with ID `tokenrouter-model-gateway` which already exists in catalog. Form allowed submission but GitHub Action failed. This fix prevents such cases by validating ID uniqueness before opening the GitHub issue.

## Test plan
- [ ] Try submitting form with existing ID (e.g., `tokenrouter-model-gateway`)
- [ ] Verify error message appears and form doesn't submit
- [ ] Try submitting with new unique ID
- [ ] Verify auto-generated ID works when title doesn't conflict

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate catalog IDs in the form by automatically deriving a unique ID from the title when needed.
  * Updated example selection so it no longer copies IDs directly, allowing automatic unique ID generation.
  * Added a clearer validation error when a submitted (trimmed) ID already exists in the catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->