### PR TITLE
fix: address Google Analytics review feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 # Google Analytics Tracking ID
 # Format: G-XXXXXXXXXX
 # Get your tracking ID from: https://analytics.google.com/
-VITE_GA_ID=G-D3S8VDKVR6
+VITE_GA_ID=G-XXXXXXXXXX

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { browser } from '$app/environment';
+	import { browser, dev } from '$app/environment';
 
 	const GA_ID = import.meta.env.VITE_GA_ID;
 
 	let initialized = false;
 
 	function initGA() {
-		if (!GA_ID || !browser || initialized) return;
+		if (!GA_ID || !browser || dev || initialized) return;
 
 		// Load Google Analytics script
 		const script = document.createElement('script');
@@ -21,16 +21,13 @@
 			window.dataLayer.push(args);
 		};
 		window.gtag('js', new Date());
-		window.gtag('config', GA_ID, {
-			page_path: $page.url.pathname
-		});
 
 		initialized = true;
 	}
 
 	// Track page views on route change
 	$effect(() => {
-		if (browser && initialized && $page.url.pathname) {
+		if (browser && !dev && initialized && $page.url.pathname) {
 			window.gtag?.('config', GA_ID, {
 				page_path: $page.url.pathname
 			});


### PR DESCRIPTION
## Summary
Fix review feedback from PR #66 to improve Google Analytics implementation.

## Changes
- **Remove duplicate page view tracking** - Remove `config` call from `initGA()` to prevent double-counting initial page view. The `$effect` block now handles all page view tracking including the initial load.
- **Disable tracking in development** - Import `dev` from `$app/environment` and add checks to prevent GA initialization in dev mode
- **Use placeholder in .env.example** - Replace real tracking ID with `G-XXXXXXXXXX` to prevent accidental tracking to production property

## Review Feedback Addressed
- ✅ Gemini: Duplicate page view tracking on initial load (High priority)
- ✅ Gemini: Import `dev` for development mode check (Medium priority)
- ✅ Gemini: Add `dev` check in `initGA()` (Medium priority)
- ✅ Gemini: Use placeholder in `.env.example` (Medium priority)
- ✅ Codex: Avoid double-counting initial page view (P2)

## Testing
- Type check: ✅ Passed
- Lint: ✅ Passed
- Manual testing: GA should not initialize in dev mode, single page view per navigation in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Google Analytics configuration example to use a generic placeholder format

* **Bug Fixes**
  * Google Analytics tracking is now disabled when running in development mode, preventing test data from affecting production metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->