### PR TITLE
fix: GA not receiving data - fix env injection and script loading

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,7 +28,9 @@ jobs:
       - run: npm ci
 
       - name: Create .env file
-        run: echo "VITE_GA_ID=${{ vars.VITE_GA_ID }}" > .env
+        run: echo "VITE_GA_ID=$VITE_GA_ID" > .env
+        env:
+          VITE_GA_ID: ${{ vars.VITE_GA_ID }}
 
       - run: npm run build
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -27,9 +27,10 @@ jobs:
 
       - run: npm ci
 
+      - name: Create .env file
+        run: echo "VITE_GA_ID=${{ vars.VITE_GA_ID }}" > .env
+
       - run: npm run build
-        env:
-          VITE_GA_ID: ${{ vars.VITE_GA_ID }}
 
       - uses: actions/configure-pages@v5
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,7 +28,12 @@ jobs:
       - run: npm ci
 
       - name: Create .env file
-        run: echo "VITE_GA_ID=$VITE_GA_ID" > .env
+        run: |
+          if [ -z "${VITE_GA_ID:-}" ]; then
+            echo "VITE_GA_ID is required but not set" >&2
+            exit 1
+          fi
+          printf 'VITE_GA_ID=%s\n' "$VITE_GA_ID" > .env
         env:
           VITE_GA_ID: ${{ vars.VITE_GA_ID }}
 

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -4,30 +4,36 @@
 
 	const GA_ID = import.meta.env.VITE_GA_ID;
 
-	let initialized = false;
+	let initialized = $state(false);
+	let scriptLoaded = $state(false);
 
 	function initGA() {
 		if (!GA_ID || !browser || dev || initialized) return;
 
-		// Load Google Analytics script
-		const script = document.createElement('script');
-		script.async = true;
-		script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
-		document.head.appendChild(script);
-
-		// Initialize gtag
+		// Initialize gtag function first
 		window.dataLayer = window.dataLayer || [];
 		window.gtag = function gtag(...args: unknown[]) {
 			window.dataLayer.push(args);
 		};
 		window.gtag('js', new Date());
+		// Don't send initial page view - let $effect handle it
+		window.gtag('config', GA_ID, { send_page_view: false });
+
+		// Load Google Analytics script
+		const script = document.createElement('script');
+		script.async = true;
+		script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+		script.onload = () => {
+			scriptLoaded = true;
+		};
+		document.head.appendChild(script);
 
 		initialized = true;
 	}
 
 	// Track page views on route change
 	$effect(() => {
-		if (browser && !dev && initialized && $page.url.pathname) {
+		if (browser && !dev && initialized && scriptLoaded && $page.url.pathname) {
 			window.gtag?.('config', GA_ID, {
 				page_path: $page.url.pathname
 			});

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -5,7 +5,6 @@
 	const GA_ID = import.meta.env.VITE_GA_ID;
 
 	let initialized = $state(false);
-	let scriptLoaded = $state(false);
 
 	function initGA() {
 		if (!GA_ID || !browser || dev || initialized) return;
@@ -23,8 +22,8 @@
 		const script = document.createElement('script');
 		script.async = true;
 		script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
-		script.onload = () => {
-			scriptLoaded = true;
+		script.onerror = () => {
+			console.warn('Google Analytics script failed to load');
 		};
 		document.head.appendChild(script);
 
@@ -33,7 +32,7 @@
 
 	// Track page views on route change
 	$effect(() => {
-		if (browser && !dev && initialized && scriptLoaded && $page.url.pathname) {
+		if (browser && !dev && initialized && $page.url.pathname) {
 			window.gtag?.('config', GA_ID, {
 				page_path: $page.url.pathname
 			});

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -715,7 +715,7 @@
 		"status": "active"
 	},
 	{
-		"id": "bansos-gemini-plus-3bulan-sim",
+		"id": "gemini-plus-3bulan-sim",
 		"title": "Bansos Gemini Plus 3bulan Sim",
 		"provider": "Bima3",
 		"description": "Bisa klaim Gemini Plus 3 bulan di aplikasi Bima 3.",

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -716,7 +716,7 @@
 	},
 	{
 		"id": "gemini-plus-3bulan-sim",
-		"title": "Bansos Gemini Plus 3bulan Sim",
+		"title": "Gemini Plus 3 Bulan via Bima+",
 		"provider": "Bima3",
 		"description": "Bisa klaim Gemini Plus 3 bulan di aplikasi Bima 3.",
 		"benefits": [

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -43,7 +43,7 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"bansos-gemini-plus-3bulan-sim": [
+	"gemini-plus-3bulan-sim": [
 		{
 			"login": "wauputr4",
 			"name": "wauputr4",


### PR DESCRIPTION
## Problem
Google Analytics dashboard shows: 'Belum ada data yang diterima dari situs'

## Root Cause
1. **Vite env not injected** - `VITE_GA_ID` from GitHub variables wasn't available during build. Vite reads from `.env` file, not just process.env.
2. **Race condition** - `` fires before GA script finishes loading, so tracking calls are lost.
3. **No initial page view** - Previous fix removed all page view tracking.

## Solution
1. **Create .env file in workflow** - Write `VITE_GA_ID` to `.env` file before build so Vite can read it
2. **Wait for script load** - Add `scriptLoaded` state that becomes true when GA script's `onload` fires
3. **Disable auto page view in init** - Use `send_page_view: false` in initGA, let `` handle all page tracking
4. **Reactive tracking** - `` now waits for both `initialized` AND `scriptLoaded` before sending page views

## Changes
- `.github/workflows/deploy-pages.yml` - Create .env file with VITE_GA_ID before build
- `src/lib/components/Analytics.svelte` - Add scriptLoaded state, disable auto page view in init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Analytics initialization and route-based page-view tracking to better control when events are emitted.
* **Chores**
  * Updated the Pages build to generate a local analytics configuration file during build, validating the analytics ID and removing redundant inline setup.
* **Content Updates**
  * Updated the Bansos “Gemini Plus 3 Bulan via Bima+” entry identifier/title, including the corresponding credits/contributor dataset key rename.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->