### PR TITLE
Tambah bansos: Gemini Pro Head 12 Bulan

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -743,5 +743,31 @@
 		"tags": ["AI Credits", "Gemini", "Bima"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "g",
+		"title": "Gemini Pro Head 12 Bulan",
+		"provider": "Google",
+		"description": "Gemini Pro Head 12 Bulan 5TB Free dan bisa invite member sampai 5 email.",
+		"benefits": [
+			"Gemini Pro Head 12 Bulan",
+			"Storage 5 TB",
+			"Bisa invite 5 member",
+			"All Benefit Pro"
+		],
+		"validity": {
+			"type": "forever"
+		},
+		"requirements": ["Telegram"],
+		"publishedAt": "2026-06-17",
+		"source": "https://www.threads.com/@godentopup/post/DZqx_6Jga_u?xmt=AQG0L0gPTpoWx-8QC3fVSgKEzP89tJ_OPuLOn4Lc4vK141BKI6X1tJl39XItVpVbd89GA6zY&slof=1",
+		"contributor": {
+			"name": "Goden",
+			"url": "https://github.com/godencreative-alt"
+		},
+		"ctaLink": "https://t.me/gemini12pro_bot?start=inv_RY-UB3NHFV4",
+		"tags": ["Gemini"],
+		"featured": true,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -43,14 +43,6 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"gemini-plus-3bulan-sim": [
-		{
-			"login": "wauputr4",
-			"name": "wauputr4",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=wauputr4"
-		}
-	],
 	"dahono-labs-ai-api": [
 		{
 			"login": "wauputr4",
@@ -81,6 +73,22 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
+	"g": [
+		{
+			"login": "godencreative-alt",
+			"name": "godencreative-alt",
+			"avatarUrl": "https://github.com/godencreative-alt.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=godencreative-alt"
+		}
+	],
+	"gemini-plus-3bulan-sim": [
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=wauputr4"
+		}
+	],
 	"google-ai-pro-4-bulan": [
 		{
 			"login": "muhakbarcom",
@@ -93,6 +101,12 @@
 			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/0f58ce2b1fa0a25d8d14434565519f69d4bd5628"
+		},
+		{
+			"login": "github-actions[bot]",
+			"name": "github-actions[bot]",
+			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/1abf005d93fb0d9d50189b09f70e16b841865958"
 		}
 	],
 	"google-startups-cloud": [


### PR DESCRIPTION
Auto-generated from #69.

## Summary
- Add Gemini Pro Head 12 Bulan to the bansos list.
- Source payload comes from the contributor issue.

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the Gemini Pro Head 12 Bulan assistance program from Google. Features include 5TB cloud storage, support for up to 5 member invitations, and perpetual program validity. Access available via Telegram.

* **Chores**
  * Updated internal contributor records and program metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->