### PR TITLE
Tambah bansos: Claude Opus 4.8, Sonnet 4.6, and Haiku Gratis credit $350

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -767,5 +767,27 @@
 		"tags": ["AI", "API", "Developer"],
 		"featured": true,
 		"status": "active"
+	},
+	{
+		"id": "claude-opus-48-sonnet-46-and-haiku-gratis-credit-350",
+		"title": "Claude Opus 4.8, Sonnet 4.6, and Haiku Gratis credit $350",
+		"provider": "Aerolink",
+		"description": "Claude Opus 4.8, Sonnet 4.6, and Haiku Gratis credit $350 dari aerolink",
+		"benefits": ["Credit $350", "Claude Opus 4.8", "Sonnet 4.6", "Haiku"],
+		"promoCode": "FRD8FHI",
+		"validity": {
+			"type": "uncertain"
+		},
+		"requirements": ["Daftar akun"],
+		"publishedAt": "2026-06-17",
+		"source": "Aerolink",
+		"contributor": {
+			"name": "Akbar",
+			"url": "http://github.com/muhakbarcom"
+		},
+		"ctaLink": "https://aerolink.lat/register?ref=FRD8FHI",
+		"tags": ["AI Credits"],
+		"featured": true,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -43,6 +43,28 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
+	"claude-opus-48-sonnet-46-and-haiku-gratis-credit-350": [
+		{
+			"login": "muhakbarcom",
+			"name": "muhakbarcom",
+			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
+		}
+	],
+	"codecrafters-free-token": [
+		{
+			"login": "rupadana",
+			"name": "rupadana",
+			"avatarUrl": "https://github.com/rupadana.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=rupadana"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/c00f2a3be28caf01ee3ec8b5059b3a012feca7f7"
+		}
+	],
 	"dahono-labs-ai-api": [
 		{
 			"login": "wauputr4",
@@ -71,14 +93,6 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
-		}
-	],
-	"codecrafters-free-token": [
-		{
-			"login": "rupadana",
-			"name": "rupadana",
-			"avatarUrl": "https://github.com/rupadana.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=rupadana"
 		}
 	],
 	"gemini-plus-3bulan-sim": [


### PR DESCRIPTION
Auto-generated from #73.

## Summary
- Add Claude Opus 4.8, Sonnet 4.6, and Haiku Gratis credit $350 to the bansos list.
- Source payload comes from the contributor issue.

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched a new $350 free credit promotion for Claude Opus 4.8, Sonnet 4.6, and Haiku models available through Aerolink
  * Promotion is now actively featured with a dedicated promo code and streamlined registration process
  * Credits are accessible immediately upon completing registration with the provided promotion code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->