### PR TITLE
chore: remove github-actions[bot] from commit-contributors

### DIFF
--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -11,12 +11,6 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8105e48b0a6e5449d1fff3829b5968b02d84cdca4"
-		},
-		{
-			"login": "github-actions[bot]",
-			"name": "github-actions[bot]",
-			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/d279ea9e10c36b878f99c47ce28b4d6a0b8c9d01"
 		}
 	],
 	"aiclass-asean-courses": [
@@ -107,12 +101,6 @@
 			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/0f58ce2b1fa0a25d8d14434565519f69d4bd5628"
-		},
-		{
-			"login": "github-actions[bot]",
-			"name": "github-actions[bot]",
-			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/1abf005d93fb0d9d50189b09f70e16b841865958"
 		}
 	],
 	"google-startups-cloud": [


### PR DESCRIPTION
## Ringkas
Perbaikan ini membersihkan nilai kepemilikan contributor yang salah pada `src/lib/data/commit-contributors.json` dengan menghapus entri `github-actions[bot]` yang semestinya tidak dianggap sebagai contributor manusia.

## Detail
- Hapus semua entri `github-actions[bot]` dari file commit contributors.
- Tetap pertahankan mapping contributor manusia yang sudah ada.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor information in the data files by replacing entries with alternate contributor details and associated commit references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->