### PR TITLE
Tambah bansos: Free stream Fifa World Cup 2026 No Iklan

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -850,5 +850,31 @@
 		"tags": ["Domain", "Promo", "Diskon"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "f",
+		"title": "Free stream Fifa World Cup 2026 No Iklan",
+		"provider": "Tvstreamindonesia",
+		"description": "Nonton FIFA World Cup 2026 secara gratis dengan kualitas HD, tanpa iklan mengganggu dan dapat diakses dari berbagai perangkat seperti smartphone, tablet, dan PC.",
+		"benefits": [
+			"Streaming FIFA World Cup 2026 Gratis Saluran RTB GO",
+			"Tanpa Iklan Mengganggu",
+			"Kualitas HD Stabil",
+			"Support Android, iPhone & PC"
+		],
+		"validity": {
+			"type": "uncertain"
+		},
+		"requirements": [
+			"Buka website tvstreamindonesia.my.id",
+			"Cari Saluran RTB GO untuk nonton FIFA world cup 2026",
+			"Klik channel atau tombol Play Streaming"
+		],
+		"publishedAt": "2026-06-18",
+		"source": "https://t.me/tvstreamindonesia",
+		"ctaLink": "http://tvstreamindonesia.my.id",
+		"tags": ["Free Tier"],
+		"featured": true,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -852,7 +852,7 @@
 		"status": "active"
 	},
 	{
-		"id": "f",
+		"id": "tvstreamindonesia-fifa-2026",
 		"title": "Free stream Fifa World Cup 2026 No Iklan",
 		"provider": "Tvstreamindonesia",
 		"description": "Nonton FIFA World Cup 2026 secara gratis dengan kualitas HD, tanpa iklan mengganggu dan dapat diakses dari berbagai perangkat seperti smartphone, tablet, dan PC.",
@@ -872,7 +872,7 @@
 		],
 		"publishedAt": "2026-06-18",
 		"source": "https://t.me/tvstreamindonesia",
-		"ctaLink": "http://tvstreamindonesia.my.id",
+		"ctaLink": "https://tvstreamindonesia.my.id",
 		"tags": ["Free Tier"],
 		"featured": true,
 		"status": "active"

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -11,6 +11,12 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8105e48b0a6e5449d1fff3829b5968b02d84cdca4"
+		},
+		{
+			"login": "github-actions[bot]",
+			"name": "github-actions[bot]",
+			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/d279ea9e10c36b878f99c47ce28b4d6a0b8c9d01"
 		}
 	],
 	"aiclass-asean-courses": [
@@ -81,6 +87,14 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
+	"f": [
+		{
+			"login": "bang-joe",
+			"name": "bang-joe",
+			"avatarUrl": "https://github.com/bang-joe.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=bang-joe"
+		}
+	],
 	"gemini-plus-3bulan-sim": [
 		{
 			"login": "wauputr4",
@@ -101,6 +115,12 @@
 			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/0f58ce2b1fa0a25d8d14434565519f69d4bd5628"
+		},
+		{
+			"login": "github-actions[bot]",
+			"name": "github-actions[bot]",
+			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/1abf005d93fb0d9d50189b09f70e16b841865958"
 		}
 	],
 	"google-startups-cloud": [
@@ -229,6 +249,20 @@
 			"name": "fazaimron27",
 			"avatarUrl": "https://github.com/fazaimron27.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=fazaimron27"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/ea8cc9d8295abb15223cc5ad15d40cd817b25220"
+		}
+	],
+	"sumopod-domain-rp1": [
+		{
+			"login": "renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/384d22a87de9577369d639455fe4a590a3e27df7"
 		}
 	],
 	"tokenrouter-minimax-m3-free": [
@@ -253,20 +287,26 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
-	"xiaomi-mimo-gratis-2": [
-		{
-			"login": "muhakbarcom",
-			"name": "muhakbarcom",
-			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
-		}
-	],
 	"xai-grok-api-credits": [
 		{
 			"login": "renzie2161",
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"xiaomi-mimo-gratis-2": [
+		{
+			"login": "muhakbarcom",
+			"name": "muhakbarcom",
+			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/a47c50b332c6a2663fc24fe78d59c34138b8c717"
 		}
 	],
 	"zcode-glm-52-free": [

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -11,12 +11,6 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8105e48b0a6e5449d1fff3829b5968b02d84cdca4"
-		},
-		{
-			"login": "github-actions[bot]",
-			"name": "github-actions[bot]",
-			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/d279ea9e10c36b878f99c47ce28b4d6a0b8c9d01"
 		}
 	],
 	"aiclass-asean-courses": [
@@ -87,14 +81,6 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"tvstreamindonesia-fifa-2026": [
-		{
-			"login": "bang-joe",
-			"name": "bang-joe",
-			"avatarUrl": "https://github.com/bang-joe.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=bang-joe"
-		}
-	],
 	"gemini-plus-3bulan-sim": [
 		{
 			"login": "wauputr4",
@@ -115,12 +101,6 @@
 			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/0f58ce2b1fa0a25d8d14434565519f69d4bd5628"
-		},
-		{
-			"login": "github-actions[bot]",
-			"name": "github-actions[bot]",
-			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/1abf005d93fb0d9d50189b09f70e16b841865958"
 		}
 	],
 	"google-startups-cloud": [
@@ -249,20 +229,6 @@
 			"name": "fazaimron27",
 			"avatarUrl": "https://github.com/fazaimron27.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=fazaimron27"
-		},
-		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/ea8cc9d8295abb15223cc5ad15d40cd817b25220"
-		}
-	],
-	"sumopod-domain-rp1": [
-		{
-			"login": "renzie2161",
-			"name": "Renzie2161",
-			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/384d22a87de9577369d639455fe4a590a3e27df7"
 		}
 	],
 	"tokenrouter-minimax-m3-free": [
@@ -287,6 +253,14 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
+	"xiaomi-mimo-gratis-2": [
+		{
+			"login": "muhakbarcom",
+			"name": "muhakbarcom",
+			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
+		}
+	],
 	"xai-grok-api-credits": [
 		{
 			"login": "renzie2161",
@@ -295,26 +269,20 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"xiaomi-mimo-gratis-2": [
-		{
-			"login": "muhakbarcom",
-			"name": "muhakbarcom",
-			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
-		},
-		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/a47c50b332c6a2663fc24fe78d59c34138b8c717"
-		}
-	],
 	"zcode-glm-52-free": [
 		{
 			"login": "wauputr4",
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/692fa746e0322d388932fdcfd8a28992267ff15a"
+		}
+	],
+	"tvstreamindonesia-fifa-2026": [
+		{
+			"login": "bang-joe",
+			"name": "bang-joe",
+			"avatarUrl": "https://github.com/bang-joe.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=bang-joe"
 		}
 	]
 }

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -87,7 +87,7 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"f": [
+	"tvstreamindonesia-fifa-2026": [
 		{
 			"login": "bang-joe",
 			"name": "bang-joe",


### PR DESCRIPTION
Auto-generated from #83.

## Summary
- Add Free stream Fifa World Cup 2026 No Iklan to the bansos list.
- Source payload comes from the contributor issue.

Closes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new ad-free FIFA World Cup 2026 streaming offer with HD/no-ads benefits and access details.

* **Chores**
  * Refreshed contributor credits and related attribution records for the new offer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->