### PR TITLE
Tambah bansos: Free $200 Credit API LLM Populer

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -900,6 +900,25 @@
 		},
 		"ctaLink": "https://www.rumahweb.com/domain-gratis/",
 		"tags": ["Domain", "Free Tier", "Diskon", "Gratisan"],
+	},
+	{
+		"id": "f",
+		"title": "Free $200 Credit API LLM Populer",
+		"provider": "AgentRouter",
+		"description": "Instant dapat  $200 setelah signup \n\nada 10 model LLM yang bisa dipakai melalui API KEY",
+		"benefits": ["Free Signup Credits"],
+		"validity": {
+			"type": "forever"
+		},
+		"requirements": ["Signup"],
+		"publishedAt": "2026-06-18",
+		"source": "https://agentrouter.org/register?aff=qdG1",
+		"contributor": {
+			"name": "Hamba Allah",
+			"url": "https://github.com/adefebrian"
+		},
+		"ctaLink": "https://agentrouter.org/register?aff=qdG1",
+		"tags": ["AI", "AI Credits", "API"],
 		"featured": true,
 		"status": "active"
 	}

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -899,18 +899,18 @@
 			"url": "https://github.com/inirey"
 		},
 		"ctaLink": "https://www.rumahweb.com/domain-gratis/",
-		"tags": ["Domain", "Free Tier", "Diskon", "Gratisan"],
+		"tags": ["Domain", "Free Tier", "Diskon", "Gratisan"]
 	},
 	{
-		"id": "f",
+		"id": "agentrouter-free-credits",
 		"title": "Free $200 Credit API LLM Populer",
 		"provider": "AgentRouter",
-		"description": "Instant dapat  $200 setelah signup \n\nada 10 model LLM yang bisa dipakai melalui API KEY",
+		"description": "Langsung dapat $200 setelah mendaftar.\n\nTersedia 10 model LLM yang bisa digunakan melalui API key.",
 		"benefits": ["Free Signup Credits"],
 		"validity": {
 			"type": "forever"
 		},
-		"requirements": ["Signup"],
+		"requirements": ["Daftar akun"],
 		"publishedAt": "2026-06-18",
 		"source": "https://agentrouter.org/register?aff=qdG1",
 		"contributor": {

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -11,6 +11,12 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8105e48b0a6e5449d1fff3829b5968b02d84cdca4"
+		},
+		{
+			"login": "github-actions[bot]",
+			"name": "github-actions[bot]",
+			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/d279ea9e10c36b878f99c47ce28b4d6a0b8c9d01"
 		}
 	],
 	"aiclass-asean-courses": [
@@ -81,6 +87,14 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
+	"f": [
+		{
+			"login": "adefebrian",
+			"name": "Adefebrian",
+			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
+		}
+	],
 	"gemini-plus-3bulan-sim": [
 		{
 			"login": "wauputr4",
@@ -101,6 +115,12 @@
 			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/0f58ce2b1fa0a25d8d14434565519f69d4bd5628"
+		},
+		{
+			"login": "github-actions[bot]",
+			"name": "github-actions[bot]",
+			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/1abf005d93fb0d9d50189b09f70e16b841865958"
 		}
 	],
 	"google-startups-cloud": [
@@ -229,6 +249,20 @@
 			"name": "fazaimron27",
 			"avatarUrl": "https://github.com/fazaimron27.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=fazaimron27"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/ea8cc9d8295abb15223cc5ad15d40cd817b25220"
+		}
+	],
+	"sumopod-domain-rp1": [
+		{
+			"login": "renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/384d22a87de9577369d639455fe4a590a3e27df7"
 		}
 	],
 	"tokenrouter-minimax-m3-free": [
@@ -253,12 +287,18 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
-	"xiaomi-mimo-gratis-2": [
+	"tvstreamindonesia-fifa-2026": [
 		{
-			"login": "muhakbarcom",
-			"name": "muhakbarcom",
-			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
+			"login": "bang-joe",
+			"name": "bang-joe",
+			"avatarUrl": "https://github.com/bang-joe.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=bang-joe"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/91825af921db233219c2d05d852b9458a1657ac8"
 		}
 	],
 	"xai-grok-api-credits": [
@@ -267,6 +307,20 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"xiaomi-mimo-gratis-2": [
+		{
+			"login": "muhakbarcom",
+			"name": "muhakbarcom",
+			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/a47c50b332c6a2663fc24fe78d59c34138b8c717"
 		}
 	],
 	"zcode-glm-52-free": [

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -11,12 +11,6 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8105e48b0a6e5449d1fff3829b5968b02d84cdca4"
-		},
-		{
-			"login": "github-actions[bot]",
-			"name": "github-actions[bot]",
-			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/d279ea9e10c36b878f99c47ce28b4d6a0b8c9d01"
 		}
 	],
 	"aiclass-asean-courses": [
@@ -87,14 +81,6 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"f": [
-		{
-			"login": "adefebrian",
-			"name": "Adefebrian",
-			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
-		}
-	],
 	"gemini-plus-3bulan-sim": [
 		{
 			"login": "wauputr4",
@@ -115,12 +101,6 @@
 			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/0f58ce2b1fa0a25d8d14434565519f69d4bd5628"
-		},
-		{
-			"login": "github-actions[bot]",
-			"name": "github-actions[bot]",
-			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/1abf005d93fb0d9d50189b09f70e16b841865958"
 		}
 	],
 	"google-startups-cloud": [
@@ -249,20 +229,6 @@
 			"name": "fazaimron27",
 			"avatarUrl": "https://github.com/fazaimron27.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=fazaimron27"
-		},
-		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/ea8cc9d8295abb15223cc5ad15d40cd817b25220"
-		}
-	],
-	"sumopod-domain-rp1": [
-		{
-			"login": "renzie2161",
-			"name": "Renzie2161",
-			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/384d22a87de9577369d639455fe4a590a3e27df7"
 		}
 	],
 	"tokenrouter-minimax-m3-free": [
@@ -287,18 +253,12 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
-	"tvstreamindonesia-fifa-2026": [
+	"xiaomi-mimo-gratis-2": [
 		{
-			"login": "bang-joe",
-			"name": "bang-joe",
-			"avatarUrl": "https://github.com/bang-joe.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=bang-joe"
-		},
-		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/91825af921db233219c2d05d852b9458a1657ac8"
+			"login": "muhakbarcom",
+			"name": "muhakbarcom",
+			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
 		}
 	],
 	"xai-grok-api-credits": [
@@ -307,20 +267,6 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
-		}
-	],
-	"xiaomi-mimo-gratis-2": [
-		{
-			"login": "muhakbarcom",
-			"name": "muhakbarcom",
-			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
-		},
-		{
-			"login": "wauputr4",
-			"name": "Wauputra",
-			"avatarUrl": "https://github.com/wauputr4.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commit/a47c50b332c6a2663fc24fe78d59c34138b8c717"
 		}
 	],
 	"zcode-glm-52-free": [
@@ -345,6 +291,14 @@
 			"name": "inirey",
 			"avatarUrl": "https://github.com/inirey.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=inirey"
+		}
+	],
+	"agentrouter-free-credits": [
+		{
+			"login": "adefebrian",
+			"name": "Adefebrian",
+			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
 		}
 	]
 }


### PR DESCRIPTION
Auto-generated from #87.

## Summary
- Add Free $200 Credit API LLM Populer to the bansos list.
- Source payload comes from the contributor issue.

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new featured AgentRouter promotional listing offering **$200 in free API LLM credits**, with updated availability, “forever” validity, and refreshed call-to-action links.

* **Chores**
  * Updated contributor attribution data to include the latest credited contributor for the new featured listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->