### PR TITLE
fix: build crash on missing status and manual GA4 pageview tracking

### DIFF
--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -35,7 +35,7 @@
 		if (browser && !dev && initialized && $page.url.pathname) {
 			window.gtag?.('event', 'page_view', {
 				page_path: $page.url.pathname,
-				page_location: window.location.href,
+				page_location: $page.url.href,
 				page_title: document.title
 			});
 		}

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -33,8 +33,10 @@
 	// Track page views on route change
 	$effect(() => {
 		if (browser && !dev && initialized && $page.url.pathname) {
-			window.gtag?.('config', GA_ID, {
-				page_path: $page.url.pathname
+			window.gtag?.('event', 'page_view', {
+				page_path: $page.url.pathname,
+				page_location: window.location.href,
+				page_title: document.title
 			});
 		}
 	});

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -899,7 +899,9 @@
 			"url": "https://github.com/inirey"
 		},
 		"ctaLink": "https://www.rumahweb.com/domain-gratis/",
-		"tags": ["Domain", "Free Tier", "Diskon", "Gratisan"]
+		"tags": ["Domain", "Free Tier", "Diskon", "Gratisan"],
+		"featured": true,
+		"status": "active"
 	},
 	{
 		"id": "agentrouter-free-credits",


### PR DESCRIPTION
This PR fixes two main issues: 1) A build crash caused by a missing 'status' field in a JSON entry, and 2) Google Analytics 4 page views not tracking properly on SPA route changes due to missing page_view events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Highlighted a domain registration offer as featured and marked it as active in the promotions list.

* **Improvements**
  * Enhanced page-view analytics tracking to include page path, page location, and page title for richer navigation insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->