### PR TITLE
fix: render Google Analytics tag statically in HTML head for verification

### DIFF
--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -4,12 +4,9 @@
 
 	const GA_ID = import.meta.env.VITE_GA_ID;
 
-	const scriptTag = `<script>
-		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
-		gtag('js', new Date());
-		gtag('config', '${GA_ID}', { send_page_view: false });
-	</` + 'script>';
+	const scriptTag =
+		`<script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '${GA_ID}', { send_page_view: false }); </` +
+		'script>';
 
 	// Track page views on route change
 	$effect(() => {

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -4,12 +4,12 @@
 
 	const GA_ID = import.meta.env.VITE_GA_ID;
 
-	const inlineScript = `
+	const scriptTag = `<script>
 		window.dataLayer = window.dataLayer || [];
 		function gtag(){dataLayer.push(arguments);}
 		gtag('js', new Date());
 		gtag('config', '${GA_ID}', { send_page_view: false });
-	`;
+	</` + 'script>';
 
 	// Track page views on route change
 	$effect(() => {
@@ -26,6 +26,6 @@
 <svelte:head>
 	{#if GA_ID && !dev}
 		<script async src="https://www.googletagmanager.com/gtag/js?id={GA_ID}"></script>
-		{@html `<script>${inlineScript}</script>`}
+		{@html scriptTag}
 	{/if}
 </svelte:head>

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -1,27 +1,40 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { browser, dev } from '$app/environment';
+	import { dev } from '$app/environment';
+	import { tick } from 'svelte';
 
-	const GA_ID = import.meta.env.VITE_GA_ID;
+	const GA_ID = (import.meta.env.VITE_GA_ID ?? '').trim();
+	const HAS_VALID_GA_ID = /^G-[A-Z0-9]+$/.test(GA_ID);
 
+	// Construct inline script with validation and safe serialization
 	const scriptTag =
-		`<script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', '${GA_ID}', { send_page_view: false }); </` +
-		'script>';
+		`<script>
+		window.dataLayer = window.dataLayer || [];
+		window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);}
+		gtag('js', new Date());
+		gtag('config', ${JSON.stringify(GA_ID)}, { send_page_view: false });
+	</` + 'script>';
 
-	// Track page views on route change
+	// Track page views on route change (runs only in browser)
 	$effect(() => {
-		if (browser && !dev && GA_ID && $page.url.pathname) {
-			window.gtag?.('event', 'page_view', {
-				page_path: $page.url.pathname,
-				page_location: $page.url.href,
-				page_title: document.title
+		if (!dev && HAS_VALID_GA_ID && $page.url.pathname) {
+			const currentPath = $page.url.pathname;
+			const currentHref = $page.url.href;
+
+			// Wait for SvelteKit and <svelte:head> to fully update the document title
+			tick().then(() => {
+				window.gtag?.('event', 'page_view', {
+					page_path: currentPath,
+					page_location: currentHref,
+					page_title: document.title
+				});
 			});
 		}
 	});
 </script>
 
 <svelte:head>
-	{#if GA_ID && !dev}
+	{#if HAS_VALID_GA_ID && !dev}
 		<script async src="https://www.googletagmanager.com/gtag/js?id={GA_ID}"></script>
 		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html scriptTag}

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -23,6 +23,7 @@
 <svelte:head>
 	{#if GA_ID && !dev}
 		<script async src="https://www.googletagmanager.com/gtag/js?id={GA_ID}"></script>
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 		{@html scriptTag}
 	{/if}
 </svelte:head>

--- a/src/lib/components/Analytics.svelte
+++ b/src/lib/components/Analytics.svelte
@@ -4,35 +4,16 @@
 
 	const GA_ID = import.meta.env.VITE_GA_ID;
 
-	let initialized = $state(false);
-
-	function initGA() {
-		if (!GA_ID || !browser || dev || initialized) return;
-
-		// Initialize gtag function first
+	const inlineScript = `
 		window.dataLayer = window.dataLayer || [];
-		window.gtag = function gtag(...args: unknown[]) {
-			window.dataLayer.push(args);
-		};
-		window.gtag('js', new Date());
-		// Don't send initial page view - let $effect handle it
-		window.gtag('config', GA_ID, { send_page_view: false });
-
-		// Load Google Analytics script
-		const script = document.createElement('script');
-		script.async = true;
-		script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
-		script.onerror = () => {
-			console.warn('Google Analytics script failed to load');
-		};
-		document.head.appendChild(script);
-
-		initialized = true;
-	}
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+		gtag('config', '${GA_ID}', { send_page_view: false });
+	`;
 
 	// Track page views on route change
 	$effect(() => {
-		if (browser && !dev && initialized && $page.url.pathname) {
+		if (browser && !dev && GA_ID && $page.url.pathname) {
 			window.gtag?.('event', 'page_view', {
 				page_path: $page.url.pathname,
 				page_location: $page.url.href,
@@ -40,9 +21,11 @@
 			});
 		}
 	});
-
-	// Initialize on mount
-	if (browser) {
-		initGA();
-	}
 </script>
+
+<svelte:head>
+	{#if GA_ID && !dev}
+		<script async src="https://www.googletagmanager.com/gtag/js?id={GA_ID}"></script>
+		{@html `<script>${inlineScript}</script>`}
+	{/if}
+</svelte:head>


### PR DESCRIPTION
This PR fixes the Google Analytics tag verification issue by rendering the gtag.js script and initialization code statically in the HTML head of all prerendered pages using Svelte's `<svelte:head>` component. This ensures that Google's tag verification crawler can find the tag in the raw HTML without executing client-side Svelte hydration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated analytics initialization to be declarative and head-based, loading and configuring analytics only when a valid analytics ID is present.
  * Improved route-change page-view tracking to trigger on navigations (while avoiding dev-time and redundant events), including accurate page titles and current URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->