### PR TITLE
feat: show pageviews on list cards and default to Terpopuler sorting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,4 +15,4 @@ VITE_GISCUS_CATEGORY_ID=your_giscus_category_id_here
 
 # GitHub Personal Access Token (PAT) (to query collective discussion stats at list page)
 # Create a Fine-grained PAT with Read-only access to 'Discussions' and 'Metadata'.
-GITHUB_TOKEN=your_github_pat_here
+GITHUB_DISCUSS_TOKEN=your_github_pat_here

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,18 @@
 # Google Analytics Tracking ID
 # Format: G-XXXXXXXXXX
-# Get your tracking ID from: https://analytics.google.com/
 VITE_GA_ID=G-XXXXXXXXXX
+
+# Cloudflare Analytics API credentials (used server-side for popularity rankings)
+# Create a token with 'Analytics: Read' permissions under Cloudflare API Tokens.
+CF_API_TOKEN=your_cloudflare_api_token_here
+CF_ZONE_ID=your_cloudflare_zone_id_here
+
+# Giscus comments configuration
+VITE_GISCUS_REPO=wauputr4/bansos
+VITE_GISCUS_REPO_ID=R_kgDOS3nyxQ
+VITE_GISCUS_CATEGORY=General
+VITE_GISCUS_CATEGORY_ID=your_giscus_category_id_here
+
+# GitHub Personal Access Token (PAT) (to query collective discussion stats at list page)
+# Create a Fine-grained PAT with Read-only access to 'Discussions' and 'Metadata'.
+GITHUB_TOKEN=your_github_pat_here

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -17,6 +17,8 @@ declare global {
 			env: {
 				CF_API_TOKEN?: string;
 				CF_ZONE_ID?: string;
+				GITHUB_DISCUSS_TOKEN?: string;
+				VITE_GISCUS_REPO?: string;
 			};
 		}
 	}

--- a/src/lib/components/BansosCard.svelte
+++ b/src/lib/components/BansosCard.svelte
@@ -2,7 +2,11 @@
 	import { resolve } from '$app/paths';
 	import { getProviderBySlug, slugifyProvider, type BansosItem } from '$lib/data/bansos';
 
-	let { item, compact = false }: { item: BansosItem; compact?: boolean } = $props();
+	let {
+		item,
+		compact = false,
+		views = 0
+	}: { item: BansosItem; compact?: boolean; views?: number } = $props();
 	const status = $derived(item.status || 'unknown');
 
 	let showTooltip = $state(false);
@@ -22,6 +26,15 @@
 			{#each item.tags as tag (tag)}
 				<span class="tag-badge">{tag}</span>
 			{/each}
+			{#if views > 0}
+				<span
+					class="tag-badge views-badge"
+					style="gap: 0.25rem; display: inline-flex; align-items: center; color: var(--color-accent); border-color: var(--color-accent-glow);"
+				>
+					<i class="fa-regular fa-eye" style="font-size: 0.7rem;"></i>
+					{views}
+				</span>
+			{/if}
 		</div>
 		<div class="status-container">
 			<span class="status-badge status-{status}">

--- a/src/lib/components/BansosCard.svelte
+++ b/src/lib/components/BansosCard.svelte
@@ -26,15 +26,13 @@
 			{#each item.tags as tag (tag)}
 				<span class="tag-badge">{tag}</span>
 			{/each}
-			{#if views > 0}
-				<span
-					class="tag-badge views-badge"
-					style="gap: 0.25rem; display: inline-flex; align-items: center; color: var(--color-accent); border-color: var(--color-accent-glow);"
-				>
-					<i class="fa-regular fa-eye" style="font-size: 0.7rem;"></i>
-					{views}
-				</span>
-			{/if}
+			<span
+				class="tag-badge views-badge"
+				style="gap: 0.25rem; display: inline-flex; align-items: center; color: var(--color-accent); border-color: var(--color-accent-glow);"
+			>
+				<i class="fa-regular fa-eye" style="font-size: 0.7rem;"></i>
+				{views}
+			</span>
 		</div>
 		<div class="status-container">
 			<span class="status-badge status-{status}">

--- a/src/lib/components/BansosCard.svelte
+++ b/src/lib/components/BansosCard.svelte
@@ -5,8 +5,16 @@
 	let {
 		item,
 		compact = false,
-		views = 0
-	}: { item: BansosItem; compact?: boolean; views?: number } = $props();
+		views = 0,
+		comments = 0,
+		reactions = 0
+	}: {
+		item: BansosItem;
+		compact?: boolean;
+		views?: number;
+		comments?: number;
+		reactions?: number;
+	} = $props();
 	const status = $derived(item.status || 'unknown');
 
 	let showTooltip = $state(false);
@@ -33,6 +41,24 @@
 				<i class="fa-regular fa-eye" style="font-size: 0.7rem;"></i>
 				{views}
 			</span>
+			{#if comments > 0}
+				<span
+					class="tag-badge comments-badge"
+					style="gap: 0.25rem; display: inline-flex; align-items: center; color: var(--color-success); border-color: var(--color-success-glow);"
+				>
+					<i class="fa-regular fa-comment" style="font-size: 0.7rem;"></i>
+					{comments}
+				</span>
+			{/if}
+			{#if reactions > 0}
+				<span
+					class="tag-badge reactions-badge"
+					style="gap: 0.25rem; display: inline-flex; align-items: center; color: var(--color-warning); border-color: var(--color-warning-glow);"
+				>
+					<i class="fa-regular fa-thumbs-up" style="font-size: 0.7rem;"></i>
+					{reactions}
+				</span>
+			{/if}
 		</div>
 		<div class="status-container">
 			<span class="status-badge status-{status}">

--- a/src/lib/components/BansosHighlights.svelte
+++ b/src/lib/components/BansosHighlights.svelte
@@ -2,7 +2,17 @@
 	import { resolve } from '$app/paths';
 	import type { BansosItem } from '$lib/data/bansos';
 
-	let { title, icon, items }: { title: string; icon: string; items: BansosItem[] } = $props();
+	let {
+		title,
+		icon,
+		items,
+		popularityData = {}
+	}: {
+		title: string;
+		icon: string;
+		items: BansosItem[];
+		popularityData?: Record<string, number>;
+	} = $props();
 
 	let activeTooltip = $state<string | null>(null);
 </script>
@@ -25,6 +35,13 @@
 								<span class="tag-text">{tag}</span>
 							</span>
 						{/each}
+						<span
+							class="highlight-tag views-tag"
+							style="display: inline-flex; align-items: center; gap: 0.25rem; color: var(--color-accent); border-color: rgba(16, 185, 129, 0.3);"
+						>
+							<i class="fa-regular fa-eye"></i>
+							<span class="tag-text">{popularityData[item.id] || 0}</span>
+						</span>
 					</div>
 					{#if item.status !== 'expired'}
 						{#if item.validity.type === 'forever'}

--- a/src/lib/components/BansosHighlights.svelte
+++ b/src/lib/components/BansosHighlights.svelte
@@ -37,27 +37,18 @@
 								<span class="tag-text">{tag}</span>
 							</span>
 						{/each}
-						<span
-							class="highlight-tag views-tag"
-							style="display: inline-flex; align-items: center; gap: 0.25rem; color: var(--color-accent); border-color: rgba(16, 185, 129, 0.3);"
-						>
+						<span class="highlight-tag views-tag">
 							<i class="fa-regular fa-eye"></i>
 							<span class="tag-text">{popularityData[item.id] || 0}</span>
 						</span>
 						{#if (discussionStats[item.id]?.comments || 0) > 0}
-							<span
-								class="highlight-tag comments-tag"
-								style="display: inline-flex; align-items: center; gap: 0.25rem; color: var(--color-success); border-color: rgba(16, 185, 129, 0.3);"
-							>
+							<span class="highlight-tag comments-tag">
 								<i class="fa-regular fa-comment"></i>
 								<span class="tag-text">{discussionStats[item.id].comments}</span>
 							</span>
 						{/if}
 						{#if (discussionStats[item.id]?.reactions || 0) > 0}
-							<span
-								class="highlight-tag reactions-tag"
-								style="display: inline-flex; align-items: center; gap: 0.25rem; color: var(--color-warning); border-color: rgba(16, 185, 129, 0.3);"
-							>
+							<span class="highlight-tag reactions-tag">
 								<i class="fa-regular fa-thumbs-up"></i>
 								<span class="tag-text">{discussionStats[item.id].reactions}</span>
 							</span>
@@ -253,6 +244,18 @@
 		text-transform: uppercase;
 		max-width: 8rem;
 		line-height: 1;
+	}
+
+	.views-tag {
+		color: var(--color-accent) !important;
+	}
+
+	.comments-tag {
+		color: var(--color-success) !important;
+	}
+
+	.reactions-tag {
+		color: var(--color-warning) !important;
 	}
 
 	.tag-text {

--- a/src/lib/components/BansosHighlights.svelte
+++ b/src/lib/components/BansosHighlights.svelte
@@ -6,12 +6,14 @@
 		title,
 		icon,
 		items,
-		popularityData = {}
+		popularityData = {},
+		discussionStats = {}
 	}: {
 		title: string;
 		icon: string;
 		items: BansosItem[];
 		popularityData?: Record<string, number>;
+		discussionStats?: Record<string, { comments: number; reactions: number }>;
 	} = $props();
 
 	let activeTooltip = $state<string | null>(null);
@@ -42,6 +44,24 @@
 							<i class="fa-regular fa-eye"></i>
 							<span class="tag-text">{popularityData[item.id] || 0}</span>
 						</span>
+						{#if (discussionStats[item.id]?.comments || 0) > 0}
+							<span
+								class="highlight-tag comments-tag"
+								style="display: inline-flex; align-items: center; gap: 0.25rem; color: var(--color-success); border-color: rgba(16, 185, 129, 0.3);"
+							>
+								<i class="fa-regular fa-comment"></i>
+								<span class="tag-text">{discussionStats[item.id].comments}</span>
+							</span>
+						{/if}
+						{#if (discussionStats[item.id]?.reactions || 0) > 0}
+							<span
+								class="highlight-tag reactions-tag"
+								style="display: inline-flex; align-items: center; gap: 0.25rem; color: var(--color-warning); border-color: rgba(16, 185, 129, 0.3);"
+							>
+								<i class="fa-regular fa-thumbs-up"></i>
+								<span class="tag-text">{discussionStats[item.id].reactions}</span>
+							</span>
+						{/if}
 					</div>
 					{#if item.status !== 'expired'}
 						{#if item.validity.type === 'forever'}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -34,6 +34,7 @@
 	let githubStars: number | string = $state('-');
 	let githubPrs: number | string = $state('-');
 	let githubContributors: GithubContributor[] = $state([]);
+	let popularityData: Record<string, number> = $state({});
 
 	function formatNumber(num: number | string) {
 		if (typeof num !== 'number') return num;
@@ -80,6 +81,13 @@
 						contributors: githubContributors
 					})
 				);
+			})
+			.catch(() => {});
+
+		fetch('/api/popularity')
+			.then((res) => (res.ok ? res.json() : {}))
+			.then((data) => {
+				popularityData = data;
 			})
 			.catch(() => {});
 	});
@@ -213,10 +221,16 @@
 					items={featuredBansosList}
 					title="Rekomendasi Utama"
 					icon="fa-solid fa-fire"
+					{popularityData}
 				/>
 			{/if}
 			{#if latestBansosList.length > 0}
-				<BansosHighlights items={latestBansosList} title="Bansos Terbaru" icon="fa-solid fa-bolt" />
+				<BansosHighlights
+					items={latestBansosList}
+					title="Bansos Terbaru"
+					icon="fa-solid fa-bolt"
+					{popularityData}
+				/>
 			{/if}
 		</div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,6 +35,7 @@
 	let githubPrs: number | string = $state('-');
 	let githubContributors: GithubContributor[] = $state([]);
 	let popularityData: Record<string, number> = $state({});
+	let discussionStats: Record<string, { comments: number; reactions: number }> = $state({});
 
 	function formatNumber(num: number | string) {
 		if (typeof num !== 'number') return num;
@@ -88,6 +89,13 @@
 			.then((res) => (res.ok ? res.json() : {}))
 			.then((data) => {
 				popularityData = data;
+			})
+			.catch(() => {});
+
+		fetch('/api/discussion-stats')
+			.then((res) => (res.ok ? res.json() : {}))
+			.then((data) => {
+				discussionStats = data;
 			})
 			.catch(() => {});
 	});
@@ -222,6 +230,7 @@
 					title="Rekomendasi Utama"
 					icon="fa-solid fa-fire"
 					{popularityData}
+					{discussionStats}
 				/>
 			{/if}
 			{#if latestBansosList.length > 0}
@@ -230,6 +239,7 @@
 					title="Bansos Terbaru"
 					icon="fa-solid fa-bolt"
 					{popularityData}
+					{discussionStats}
 				/>
 			{/if}
 		</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -90,14 +90,18 @@
 			.then((data) => {
 				popularityData = data;
 			})
-			.catch(() => {});
+			.catch((err) => {
+				console.error('Failed to fetch popularity data:', err);
+			});
 
 		fetch('/api/discussion-stats')
 			.then((res) => (res.ok ? res.json() : {}))
 			.then((data) => {
 				discussionStats = data;
 			})
-			.catch(() => {});
+			.catch((err) => {
+				console.error('Failed to fetch discussion stats:', err);
+			});
 	});
 </script>
 

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -9,7 +9,7 @@
 	let selectedTags: string[] = $state([]);
 	let selectedStatuses: string[] = $state([]);
 	let selectedValidities: string[] = $state([]);
-	let sortOrder: 'newest' | 'oldest' | 'popular' = $state('newest');
+	let sortOrder: 'newest' | 'oldest' | 'popular' = $state('popular');
 	let filterExpanded = $state(false);
 	let currentPage = $state(1);
 	let searchQuery = $state('');
@@ -381,7 +381,7 @@
 			</div>
 			<div class="bansos-grid">
 				{#each paginatedBansos as item (item.id)}
-					<BansosCard {item} />
+					<BansosCard {item} views={popularityData[item.id] || 0} />
 				{/each}
 			</div>
 			<Pagination bind:currentPage {totalPages} />

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -9,7 +9,7 @@
 	let selectedTags: string[] = $state([]);
 	let selectedStatuses: string[] = $state([]);
 	let selectedValidities: string[] = $state([]);
-	let sortOrder: 'newest' | 'oldest' | 'popular' = $state('popular');
+	let sortOrder: 'newest' | 'oldest' | 'popular' | 'comments' | 'reactions' = $state('popular');
 	let filterExpanded = $state(false);
 	let currentPage = $state(1);
 	let searchQuery = $state('');
@@ -17,6 +17,7 @@
 	const pageSize = 6;
 
 	let popularityData: Record<string, number> = $state({});
+	let discussionStats: Record<string, { comments: number; reactions: number }> = $state({});
 
 	onMount(async () => {
 		try {
@@ -26,6 +27,15 @@
 			}
 		} catch (e) {
 			console.error('Failed to load popularity data:', e);
+		}
+
+		try {
+			const res = await fetch('/api/discussion-stats');
+			if (res.ok) {
+				discussionStats = await res.json();
+			}
+		} catch (e) {
+			console.error('Failed to load discussion stats:', e);
 		}
 	});
 
@@ -84,6 +94,14 @@
 					const viewsA = popularityData[a.item.id] || 0;
 					const viewsB = popularityData[b.item.id] || 0;
 					if (viewsA !== viewsB) return viewsB - viewsA;
+				} else if (sortOrder === 'comments') {
+					const commentsA = discussionStats[a.item.id]?.comments || 0;
+					const commentsB = discussionStats[b.item.id]?.comments || 0;
+					if (commentsA !== commentsB) return commentsB - commentsA;
+				} else if (sortOrder === 'reactions') {
+					const reactionsA = discussionStats[a.item.id]?.reactions || 0;
+					const reactionsB = discussionStats[b.item.id]?.reactions || 0;
+					if (reactionsA !== reactionsB) return reactionsB - reactionsA;
 				}
 				return sortOrder === 'oldest' ? a.index - b.index : b.index - a.index;
 			})
@@ -241,6 +259,20 @@
 								</button>
 								<button
 									class="tag-btn"
+									class:active={sortOrder === 'comments'}
+									onclick={() => (sortOrder = 'comments')}
+								>
+									Komentar
+								</button>
+								<button
+									class="tag-btn"
+									class:active={sortOrder === 'reactions'}
+									onclick={() => (sortOrder = 'reactions')}
+								>
+									Reaksi
+								</button>
+								<button
+									class="tag-btn"
 									class:active={sortOrder === 'newest'}
 									onclick={() => (sortOrder = 'newest')}
 								>
@@ -366,7 +398,7 @@
 						selectedTags = [];
 						selectedStatuses = [];
 						selectedValidities = [];
-						sortOrder = 'newest';
+						sortOrder = 'popular';
 						searchQuery = '';
 						currentPage = 1;
 					}}
@@ -381,7 +413,12 @@
 			</div>
 			<div class="bansos-grid">
 				{#each paginatedBansos as item (item.id)}
-					<BansosCard {item} views={popularityData[item.id] || 0} />
+					<BansosCard
+						{item}
+						views={popularityData[item.id] || 0}
+						comments={discussionStats[item.id]?.comments || 0}
+						reactions={discussionStats[item.id]?.reactions || 0}
+					/>
 				{/each}
 			</div>
 			<Pagination bind:currentPage {totalPages} />

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -27,6 +27,8 @@
 	const item = $derived(bansosList.find((i) => i.id === data.id) || data.item);
 	const views = $derived(item ? popularityData[item.id] || 0 : 0);
 
+	let commentCount = $state(0);
+
 	onMount(async () => {
 		try {
 			const res = await fetch('/api/popularity');
@@ -37,6 +39,25 @@
 			console.error('Failed to load popularity data:', e);
 		}
 	});
+
+	if (browser) {
+		const handleMessage = (event: MessageEvent) => {
+			if (event.origin !== 'https://giscus.app') return;
+			if (!(event.data && event.data.giscus)) return;
+
+			const giscusData = event.data.giscus;
+			if (giscusData.discussion && giscusData.discussion.totalCommentCount !== undefined) {
+				commentCount = giscusData.discussion.totalCommentCount;
+			}
+		};
+
+		onMount(() => {
+			window.addEventListener('message', handleMessage);
+			return () => {
+				window.removeEventListener('message', handleMessage);
+			};
+		});
+	}
 	const provider = $derived(item ? getProviderBySlug(slugifyProvider(item.provider)) : null);
 	const source = $derived(item ? getItemSource(item) : undefined);
 	const sourceIsUrl = $derived(source ? /^https?:\/\//.test(source) : false);
@@ -139,7 +160,7 @@
 			script.setAttribute('data-mapping', 'pathname');
 			script.setAttribute('data-strict', '0');
 			script.setAttribute('data-reactions-enabled', '1');
-			script.setAttribute('data-emit-metadata', '0');
+			script.setAttribute('data-emit-metadata', '1');
 			script.setAttribute('data-input-position', 'bottom');
 			script.setAttribute('data-theme', 'preferred_color_scheme');
 			script.setAttribute('data-lang', 'id');
@@ -219,6 +240,13 @@
 							>
 								<i class="fa-regular fa-eye" style="font-size: 0.7rem;"></i>
 								{views}
+							</span>
+							<span
+								class="tag-badge comments-badge"
+								style="gap: 0.25rem; display: inline-flex; align-items: center; color: var(--color-success); border-color: var(--color-success-glow);"
+							>
+								<i class="fa-regular fa-comment" style="font-size: 0.7rem;"></i>
+								{commentCount}
 							</span>
 						</div>
 						<div class="status-container">

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	/* eslint-disable svelte/no-navigation-without-resolve */
+	import { onMount } from 'svelte';
 	import { resolve } from '$app/paths';
 	import { browser } from '$app/environment';
 	import FloatingEmoji from '$lib/components/FloatingEmoji.svelte';
@@ -22,7 +23,20 @@
 
 	let { data } = $props();
 
+	let popularityData: Record<string, number> = $state({});
 	const item = $derived(bansosList.find((i) => i.id === data.id) || data.item);
+	const views = $derived(item ? popularityData[item.id] || 0 : 0);
+
+	onMount(async () => {
+		try {
+			const res = await fetch('/api/popularity');
+			if (res.ok) {
+				popularityData = await res.json();
+			}
+		} catch (e) {
+			console.error('Failed to load popularity data:', e);
+		}
+	});
 	const provider = $derived(item ? getProviderBySlug(slugifyProvider(item.provider)) : null);
 	const source = $derived(item ? getItemSource(item) : undefined);
 	const sourceIsUrl = $derived(source ? /^https?:\/\//.test(source) : false);
@@ -199,6 +213,13 @@
 							{#each item.tags as tag (tag)}
 								<span class="tag-badge">{tag}</span>
 							{/each}
+							<span
+								class="tag-badge views-badge"
+								style="gap: 0.25rem; display: inline-flex; align-items: center; color: var(--color-accent); border-color: var(--color-accent-glow);"
+							>
+								<i class="fa-regular fa-eye" style="font-size: 0.7rem;"></i>
+								{views}
+							</span>
 						</div>
 						<div class="status-container">
 							<span class="status-badge status-{status}"
@@ -382,7 +403,7 @@
 			{#if recommendedBansos.length > 0}
 				<div class="recommendation-grid">
 					{#each recommendedBansos as recommend (recommend.id)}
-						<BansosCard item={recommend} compact={true} />
+						<BansosCard item={recommend} compact={true} views={popularityData[recommend.id] || 0} />
 					{/each}
 					<a href={resolve('/list')} class="glass-card recommendation-more-card">
 						<div class="more-card-content">


### PR DESCRIPTION
Sets 'popular' (Terpopuler) as the default sorting order on the catalogue list page, and renders an eye icon badge showing the Cloudflare Analytics view counts on each bansos card when views > 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cards now include a “views” badge (eye icon) showing the view count, including when it’s 0.
  * “Views” are shown across listings, highlights, recommendations, and the item details page.
* **Changes**
  * The listings page default sort order now prioritizes popular items.
* **Bug Fixes**
  * View counts fall back to 0 when popularity data isn’t available.
* **Documentation**
  * Updated the environment variable template with Cloudflare Analytics and Giscus configuration placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->