### PR TITLE
fix: fix page view tracking using httpRequestsAdaptiveGroups

### DIFF
--- a/src/routes/api/popularity/+server.ts
+++ b/src/routes/api/popularity/+server.ts
@@ -12,29 +12,27 @@ export const GET: RequestHandler = async ({ platform }) => {
 	}
 
 	const query = `
-		query GetPageViews($zoneTag: String!, $date: Date!) {
+		query GetPageViews($zoneTag: String!, $start: DateTime!) {
 			viewer {
 				zones(filter: { zoneTag: $zoneTag }) {
-					httpRequests1mGroups(
+					httpRequestsAdaptiveGroups(
 						limit: 100
-						filter: { date_geq: $date }
-						orderBy: [sum_pageViews_DESC]
+						filter: { datetime_geq: $start }
+						orderBy: [count_DESC]
 					) {
 						dimensions {
 							clientRequestPath
 						}
-						sum {
-							pageViews
-						}
+						count
 					}
 				}
 			}
 		}
 	`;
 
-	const oneWeekAgo = new Date();
-	oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
-	const dateString = oneWeekAgo.toISOString().split('T')[0];
+	const oneDayAgo = new Date();
+	oneDayAgo.setHours(oneDayAgo.getHours() - 23);
+	const dateString = oneDayAgo.toISOString();
 
 	try {
 		const cfResponse = await fetch('https://api.cloudflare.com/client/v4/graphql', {
@@ -47,7 +45,7 @@ export const GET: RequestHandler = async ({ platform }) => {
 				query,
 				variables: {
 					zoneTag: CF_ZONE_ID,
-					date: dateString
+					start: dateString
 				}
 			})
 		});
@@ -66,13 +64,11 @@ export const GET: RequestHandler = async ({ platform }) => {
 			data?: {
 				viewer?: {
 					zones?: Array<{
-						httpRequests1mGroups?: Array<{
+						httpRequestsAdaptiveGroups?: Array<{
 							dimensions: {
 								clientRequestPath?: string;
 							};
-							sum: {
-								pageViews?: number;
-							};
+							count?: number;
 						}>;
 					}>;
 				};
@@ -90,12 +86,12 @@ export const GET: RequestHandler = async ({ platform }) => {
 			);
 		}
 
-		const rows = result?.data?.viewer?.zones?.[0]?.httpRequests1mGroups || [];
+		const rows = result?.data?.viewer?.zones?.[0]?.httpRequestsAdaptiveGroups || [];
 
 		const popularity: Record<string, number> = {};
 		for (const row of rows) {
 			const path = (row.dimensions.clientRequestPath || '').toLowerCase();
-			const views = row.sum.pageViews || 0;
+			const views = row.count || 0;
 			const match = path.match(/\/list\/([^/]+)/);
 			if (match) {
 				const bansosId = match[1];

--- a/src/routes/api/popularity/+server.ts
+++ b/src/routes/api/popularity/+server.ts
@@ -103,7 +103,7 @@ export const GET: RequestHandler = async ({ platform }) => {
 
 		return json(popularity, {
 			headers: {
-				'Cache-Control': 'public, max-age=600, s-maxage=600'
+				'Cache-Control': 'public, max-age=3600, s-maxage=3600'
 			}
 		});
 	} catch (err) {

--- a/src/routes/api/popularity/+server.ts
+++ b/src/routes/api/popularity/+server.ts
@@ -60,6 +60,9 @@ export const GET: RequestHandler = async ({ platform }) => {
 			);
 		}
 		interface CloudflareGraphQLResponse {
+			errors?: Array<{
+				message: string;
+			}>;
 			data?: {
 				viewer?: {
 					zones?: Array<{
@@ -77,6 +80,16 @@ export const GET: RequestHandler = async ({ platform }) => {
 		}
 
 		const result = (await cfResponse.json()) as CloudflareGraphQLResponse;
+
+		if (result.errors && result.errors.length > 0) {
+			const errorMsg = result.errors.map((e) => e.message).join(', ');
+			console.error('Cloudflare GraphQL errors:', errorMsg);
+			return json(
+				{ error: `Cloudflare GraphQL error: ${errorMsg}` },
+				{ status: 500 }
+			);
+		}
+
 		const rows = result?.data?.viewer?.zones?.[0]?.httpRequests1mGroups || [];
 
 		const popularity: Record<string, number> = {};
@@ -99,6 +112,7 @@ export const GET: RequestHandler = async ({ platform }) => {
 		});
 	} catch (err) {
 		const errorMessage = err instanceof Error ? err.message : 'Unknown error';
+		console.error('Failed to load popularity data:', errorMessage);
 		return json({ error: errorMessage }, { status: 500 });
 	}
 };

--- a/src/routes/api/popularity/+server.ts
+++ b/src/routes/api/popularity/+server.ts
@@ -80,10 +80,7 @@ export const GET: RequestHandler = async ({ platform }) => {
 		if (result.errors && result.errors.length > 0) {
 			const errorMsg = result.errors.map((e) => e.message).join(', ');
 			console.error('Cloudflare GraphQL errors:', errorMsg);
-			return json(
-				{ error: `Cloudflare GraphQL error: ${errorMsg}` },
-				{ status: 500 }
-			);
+			return json({ error: `Cloudflare GraphQL error: ${errorMsg}` }, { status: 500 });
 		}
 
 		const rows = result?.data?.viewer?.zones?.[0]?.httpRequestsAdaptiveGroups || [];

--- a/src/routes/api/popularity/+server.ts
+++ b/src/routes/api/popularity/+server.ts
@@ -77,7 +77,7 @@ export const GET: RequestHandler = async ({ platform }) => {
 
 		const result = (await cfResponse.json()) as CloudflareGraphQLResponse;
 
-		if (result.errors && result.errors.length > 0) {
+		if (result?.errors && result.errors.length > 0) {
 			const errorMsg = result.errors.map((e) => e.message).join(', ');
 			console.error('Cloudflare GraphQL errors:', errorMsg);
 			return json({ error: `Cloudflare GraphQL error: ${errorMsg}` }, { status: 500 });

--- a/src/routes/list/+page.svelte
+++ b/src/routes/list/+page.svelte
@@ -24,6 +24,9 @@
 			const res = await fetch('/api/popularity');
 			if (res.ok) {
 				popularityData = await res.json();
+			} else {
+				const errorDetails = await res.json().catch(() => ({}));
+				console.error('Failed to load popularity data:', res.status, errorDetails.error || '');
 			}
 		} catch (e) {
 			console.error('Failed to load popularity data:', e);

--- a/src/routes/list/[id]/+page.svelte
+++ b/src/routes/list/[id]/+page.svelte
@@ -34,6 +34,9 @@
 			const res = await fetch('/api/popularity');
 			if (res.ok) {
 				popularityData = await res.json();
+			} else {
+				const errorDetails = await res.json().catch(() => ({}));
+				console.error('Failed to load popularity data:', res.status, errorDetails.error || '');
 			}
 		} catch (e) {
 			console.error('Failed to load popularity data:', e);


### PR DESCRIPTION
This PR fixes the page view analytics resolving to 0 by migrating the query from httpRequests1mGroups (unsupported on free zones) to httpRequestsAdaptiveGroups with a 24h query range. It also exposes GraphQL errors to the client console and sets cache-control to 1 hour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed popularity API requests by safely parsing returned error details and providing more informative error reporting.
  * Enhanced logging for non-OK HTTP responses and GraphQL error conditions while continuing to return a 500 error to the client.

* **Performance**
  * Updated popularity data fetching to use adaptive grouping with a ~last-24-hours window.
  * Increased cache duration for successful popularity responses (from 10 minutes to 1 hour).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->