### PR TITLE
Tambah bansos: Free 5K-6k AI Agent Credit Gumloop (popular model available)

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -992,5 +992,40 @@
 		],
 		"featured": true,
 		"status": "active"
+	},
+	{
+		"id": "gumloop-free-credits",
+		"title": "Gratis 6,6 Ribu Kredit Agen AI di Gumloop (Tersedia Model Populer)",
+		"provider": "gumloop",
+		"description": "Gumloop menawarkan hingga 6.600 kredit agen AI gratis untuk pengguna baru. Daftar untuk menerima 5.000 kredit rutin setiap bulan, ditambah bonus tambahan satu kali sebesar 1.600 kredit di bulan pertama Anda dengan menghubungkan aplikasi pihak ketiga seperti Google Docs. Gunakan kredit ini untuk mengakses dan menjalankan berbagai model AI populer dengan mudah.",
+		"benefits": [
+			"5.000 Kredit Rutin Bulanan",
+			"1.600 Bonus Koneksi (Satu Kali)",
+			"Akses ke Berbagai Model AI Populer",
+			"Integrasi Mudah dengan Aplikasi Pihak Ketiga (mis. Google Docs)"
+		],
+		"validity": {
+			"type": "uncertain"
+		},
+		"requirements": [
+			"Buat akun baru",
+			"Hubungkan aplikasi eksternal (untuk mendapatkan kredit bonus)"
+		],
+		"instructions": [
+			"Daftar untuk membuat akun gratis di platform Gumloop.",
+			"Terima 5.000 kredit bulanan dasar Anda secara otomatis.",
+			"Hubungkan aplikasi produktivitas eksternal (seperti Google Docs) di dalam dasbor Anda untuk membuka tambahan 1.600 kredit bonus.",
+			"Pilih dari model AI yang tersedia dan mulai gunakan."
+		],
+		"publishedAt": "2026-06-20",
+		"source": "https://www.gumloop.com/pricing",
+		"contributor": {
+			"name": "Brian",
+			"url": "https://github.com/adefebrian"
+		},
+		"ctaLink": "https://www.gumloop.com/",
+		"tags": ["AI", "AI Credits", "Gratisan"],
+		"featured": false,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -97,6 +97,14 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
+	"gumloop-free-credits": [
+		{
+			"login": "adefebrian",
+			"name": "Adefebrian",
+			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
+		}
+	],
 	"gemini-plus-3bulan-sim": [
 		{
 			"login": "wauputr4",


### PR DESCRIPTION
Auto-generated from #111.

## Summary
- Add Free 5K-6k AI Agent Credit Gumloop (popular model available) to the bansos list.
- Source payload comes from the contributor issue.

Closes #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new promotional offer: **“Free 5K–6K AI Agent Credit”** from **Gumloop** to the promotions list.

* **Data Updates**
  * Added Gumloop’s promotion details (validity, eligibility, and signup instructions) to the bansos dataset.
  * Updated the contributors data to include attribution for the newly added Gumloop promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->