### PR TITLE
Tambah bansos: Proxy model dari Opencode, KiloCode, Mimo

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1029,11 +1029,11 @@
 		"status": "active"
 	},
 	{
-		"id": "f",
+		"id": "proxy-model-opencode-kilocode-mimo",
 		"title": "Proxy model dari Opencode, KiloCode, Mimo",
-		"provider": "OpenAiCompatible/AntrophicCompatible",
+		"provider": "OpenAICompatible/AnthropicCompatible",
 		"description": "proxy AI multi-upstream yang kompatibel dengan format OpenAI yang ditujukan untuk mengakses model-model AI gratis, dengan lalu lintas jaringan yang dirutekan melalui jaringan Tor untuk privasi/keamanan.\n\nProyek ini dibangun menggunakan bahasa pemrograman Go dan dilengkapi dengan antarmuka dasbor yang menggunakan teknologi HTMX.\n\nTor digunakan untuk bypass limit usage.",
-		"benefits": ["Free", "SelfHost", "AntrophicCompatible", "OpenAiCompatible"],
+		"benefits": ["Free", "SelfHost", "AnthropicCompatible", "OpenAICompatible"],
 		"validity": {
 			"type": "forever",
 			"description": "selama provider upstream ada"

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1027,5 +1027,26 @@
 		"tags": ["AI", "AI Credits", "Gratisan"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "f",
+		"title": "Proxy model dari Opencode, KiloCode, Mimo",
+		"provider": "OpenAiCompatible/AntrophicCompatible",
+		"description": "proxy AI multi-upstream yang kompatibel dengan format OpenAI yang ditujukan untuk mengakses model-model AI gratis, dengan lalu lintas jaringan yang dirutekan melalui jaringan Tor untuk privasi/keamanan.\n\nProyek ini dibangun menggunakan bahasa pemrograman Go dan dilengkapi dengan antarmuka dasbor yang menggunakan teknologi HTMX.\n\nTor digunakan untuk bypass limit usage.",
+		"benefits": ["Free", "SelfHost", "AntrophicCompatible", "OpenAiCompatible"],
+		"validity": {
+			"type": "forever",
+			"description": "selama provider upstream ada"
+		},
+		"requirements": ["Docker"],
+		"publishedAt": "2026-06-20",
+		"contributor": {
+			"name": "nofendian17",
+			"url": "https://github.com/nofendian17"
+		},
+		"ctaLink": "https://github.com/nofendian17/freegate",
+		"tags": ["AI", "Developer Tools"],
+		"featured": false,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -97,7 +97,7 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"f": [
+	"proxy-model-opencode-kilocode-mimo": [
 		{
 			"login": "nofendian17",
 			"name": "nofendian17",

--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -97,12 +97,12 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
 		}
 	],
-	"gumloop-free-credits": [
+	"f": [
 		{
-			"login": "adefebrian",
-			"name": "Adefebrian",
-			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
-			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
+			"login": "nofendian17",
+			"name": "nofendian17",
+			"avatarUrl": "https://github.com/nofendian17.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=nofendian17"
 		}
 	],
 	"gemini-plus-3bulan-sim": [
@@ -133,6 +133,14 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		}
+	],
+	"gumloop-free-credits": [
+		{
+			"login": "adefebrian",
+			"name": "Adefebrian",
+			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
 		}
 	],
 	"idwebhost-domain-gratis-1tahun": [


### PR DESCRIPTION
Auto-generated from #116.

## Summary
- Add Proxy model dari Opencode, KiloCode, Mimo to the bansos list.
- Source payload comes from the contributor issue.

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new self-hostable “freegate” proxy service listing for AI model access, featuring an HTMX-based dashboard and support for OpenAI/Anthropic-compatible formats, with Tor-based traffic routing for privacy/security.

* **Chores**
  * Updated contributor credits, including adding contributor attribution for the new proxy entry and adjusting credits for existing items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->