### PR TITLE
fix: open contributor updates as PR

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -7,6 +7,7 @@ on:
       - 'src/lib/data/bansos.json'
 permissions:
   contents: write
+  pull-requests: write
 jobs:
   update:
     runs-on: ubuntu-latest
@@ -23,9 +24,21 @@ jobs:
         run: npm run generate:commit-contributors
         env:
           BASE_REV: ${{ github.event.before }}
-      - name: Commit and push if changed
+      - name: Open pull request if changed
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add src/lib/data/commit-contributors.json
-          git diff --quiet && git diff --staged --quiet || (git commit -m "chore(data): update commit contributors [skip ci]" && git push)
+          git diff --quiet && git diff --staged --quiet && exit 0
+          git commit -m "chore(data): update commit contributors [skip ci]"
+          git push --force-with-lease origin HEAD:update-commit-contributors
+          gh pr create \
+            --base main \
+            --head update-commit-contributors \
+            --title "chore(data): update commit contributors" \
+            --body "Automated contributor map update." \
+            || gh pr edit update-commit-contributors \
+              --title "chore(data): update commit contributors" \
+              --body "Automated contributor map update."


### PR DESCRIPTION
Fix Update Contributors workflow so generated commit-contributors changes are pushed to a bot PR instead of directly to protected main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor update workflow to create pull requests instead of directly committing changes to the repository. The workflow now includes additional permission scopes and enhanced error handling for the pull request creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->