### PR TITLE
Tambah bansos: Free domain .WEB.ID

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1245,5 +1245,27 @@
 		"tags": ["AI Credits", "API"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "f",
+		"title": "Free domain .WEB.ID",
+		"provider": "Jagoan Hosting",
+		"description": "Domain gratis dari Jagoan Hosting khusus ekstensi .web.id",
+		"benefits": ["Dapatkan domain .web.id secara gratis selama 1 tahun"],
+		"promoCode": "FREEWEBID100",
+		"validity": {
+			"type": "uncertain"
+		},
+		"requirements": ["Tambahkan domain .web.id kedalam keranjang", "Masukkan kode promonya"],
+		"publishedAt": "2026-06-23",
+		"source": "Threads",
+		"contributor": {
+			"name": "Risal",
+			"url": "https://github.com/risal1107"
+		},
+		"ctaLink": "https://www.jagoanhosting.com",
+		"tags": ["Domain"],
+		"featured": false,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1247,7 +1247,7 @@
 		"status": "active"
 	},
 	{
-		"id": "f",
+		"id": "jagoanhosting-free-domain-webid",
 		"title": "Free domain .WEB.ID",
 		"provider": "Jagoan Hosting",
 		"description": "Domain gratis dari Jagoan Hosting khusus ekstensi .web.id",


### PR DESCRIPTION
Auto-generated from #145.

## Summary
- Add Free domain .WEB.ID to the bansos list.
- Source payload comes from the contributor issue.

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new free `.web.id` domain promotion from Jagoan Hosting with promo code `FREEWEBID100`, including checkout instructions (add a `.web.id` domain to your cart and apply the promo code). The offer is now active and includes a direct call-to-action link, with its validity marked as “uncertain.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->