### PR TITLE
Tambah bansos: Free domain .WEB.ID

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1267,5 +1267,27 @@
 		"tags": ["Domain"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "f",
+		"title": "Free domain .WEB.ID",
+		"provider": "Jagoan Hosting",
+		"description": "Domain gratis dari Jagoan Hosting khusus ekstensi .web.id",
+		"benefits": ["Dapatkan domain .web.id secara gratis selama 1 tahun"],
+		"promoCode": "FREEWEBID100",
+		"validity": {
+			"type": "uncertain"
+		},
+		"requirements": ["Tambahkan domain .web.id kedalam keranjang", "Masukkan kode promonya"],
+		"publishedAt": "2026-06-23",
+		"source": "https://www.jagoanhosting.com",
+		"contributor": {
+			"name": "Risal",
+			"url": "https://github.com/risal1107"
+		},
+		"ctaLink": "https://www.jagoanhosting.com",
+		"tags": ["Domain"],
+		"featured": false,
+		"status": "active"
 	}
 ]


### PR DESCRIPTION
Auto-generated from #145.

## Summary
- Add Free domain .WEB.ID to the bansos list.
- Source payload comes from the contributor issue.

Closes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bansos offer for a free .WEB.ID domain registration from Jagoan Hosting with an active promotional code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->