### PR TITLE
Tambah bansos: Free HOSTING | diskon.com

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1267,5 +1267,35 @@
 		"tags": ["Domain"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "h",
+		"title": "Free HOSTING | diskon.com",
+		"provider": "Diskon",
+		"description": "Hosting gratis Diskon.com adalah layanan hosting tanpa biaya yang memungkinkan siapa pun membuat website dan mengelola hosting dengan mudah. Hosting gratis Diskon.com cocok untuk siapa saja, bahkan buat yang ingin belajar membangun website.",
+		"benefits": [
+			"Nikmati hosting gratis selamanya tanpa kewajiban upgrade.",
+			"Control panel hosting yang mudah digunakan, cocok untuk yang baru pertama kali bikin website",
+			"Tidak perlu verifikasi ribet. Hosting gratis langsung siap dipakai.",
+			"Saat website kamu sudah gede, bisa upgrade ke hosting berbayar dengan fitur lebih lengkap."
+		],
+		"validity": {
+			"type": "forever"
+		},
+		"requirements": [
+			"Daftar Akun Pakai Email atau Google",
+			"Verifikasi Akun Kamu",
+			"Tinggal Klik, Langsung Online!"
+		],
+		"publishedAt": "2026-06-23",
+		"source": "https://diskon.com",
+		"contributor": {
+			"name": "Risal",
+			"url": "https://github.com/risal1107"
+		},
+		"ctaLink": "https://diskon.com/?go=risal.full.diskon.cloud399029",
+		"tags": ["Hosting"],
+		"featured": false,
+		"status": "active"
 	}
 ]


### PR DESCRIPTION
Auto-generated from #149.

## Summary
- Add Free HOSTING | diskon.com to the bansos list.
- Source payload comes from the contributor issue.

Closes #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new free hosting promotion from Diskon.com to available offers. Users can easily access this service by signing up with their email address or Google account, then completing account verification. This promotion provides unlimited hosting access at no cost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->