### PR TITLE
Tambah bansos: Adobe Creative Cloud Pro Rp0 | Free Trial 4 Month

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1267,5 +1267,21 @@
 		"tags": ["Domain"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "a",
+		"title": "Adobe Creative Cloud Pro Rp0 | Free Trial 4 Month",
+		"provider": "Adobe",
+		"description": "Bisa hemat Rp5.000.000 buat 4 bulan. Include Adobe Firefly",
+		"benefits": ["Adobe Creative Cloud Pro"],
+		"validity": {
+			"type": "uncertain"
+		},
+		"requirements": ["Pembayaran Menggunakan DANA/CC"],
+		"publishedAt": "2026-06-23",
+		"ctaLink": "https://s.ricoaditya.com/adobe-creative-cloud-pro",
+		"tags": ["Cloud Services", "Free Tier", "Gratisan"],
+		"featured": false,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1269,7 +1269,7 @@
 		"status": "active"
 	},
 	{
-		"id": "a",
+		"id": "adobe-creative-cloud-pro-trial",
 		"title": "Adobe Creative Cloud Pro Rp0 | Free Trial 4 Month",
 		"provider": "Adobe",
 		"description": "Bisa hemat Rp5.000.000 buat 4 bulan. Include Adobe Firefly",


### PR DESCRIPTION
Auto-generated from #153.

## Summary
- Add Adobe Creative Cloud Pro Rp0 | Free Trial 4 Month to the bansos list.
- Source payload comes from the contributor issue.

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Adobe Creative Cloud Pro”** free trial offer (**4 months**) to available benefits
  * Supports payment via **DANA** or **credit card**
  * Set as **active** and available through the platform
* **Bug Fixes**
  * Corrected the ending of the preceding **“Jagoan Hosting”** bansos entry
<!-- end of auto-generated comment: release notes by coderabbit.ai -->