### PR TITLE
Tambah bansos: Claim 7M token free

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1330,12 +1330,16 @@
 		"validity": {
 			"type": "uncertain"
 		},
-		"requirements": ["Via Nararouter"],
-		"publishedAt": "2026-06-24",
+		"requirements": [
+			"Registrasi akun di Nararouter melalui link tersedia",
+			"Verifikasi email dan login ke dashboard",
+			"Akses AI Models dan mulai gunakan 7M token gratis per hari"
+		],
+		"publishedAt": "2026-06-23",
 		"source": "https://router.bynara.id/register?ref=CJWVMGPR",
 		"contributor": {
 			"name": "AB Codeworks",
-			"url": "https://github.com/abcodeworks-cod"
+			"url": "https://github.com/abcodeworks"
 		},
 		"ctaLink": "https://router.bynara.id/register?ref=CJWVMGPR",
 		"tags": ["AI", "AI Credits", "API"],

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1313,5 +1313,33 @@
 		"tags": ["Hosting"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "claim-7m-token-free",
+		"title": "Claim 7M token free",
+		"provider": "Bynara",
+		"description": "Setiap akun mendapatkan kredit gratis hingga sekitar 7 juta per hari dan kuotanya diperbarui secara berkala, jadi cukup menarik untuk eksperimen, coding agent, maupun testing berbagai model.",
+		"benefits": [
+			"claude-sonnet-4.5",
+			"mistral-large",
+			"mistral-medium-3-5",
+			"claude-haiku-4.5",
+			"deepseek-3.2",
+			"glm-5"
+		],
+		"validity": {
+			"type": "uncertain"
+		},
+		"requirements": ["Via Nararouter"],
+		"publishedAt": "2026-06-24",
+		"source": "https://router.bynara.id/register?ref=CJWVMGPR",
+		"contributor": {
+			"name": "AB Codeworks",
+			"url": "https://github.com/abcodeworks-cod"
+		},
+		"ctaLink": "https://router.bynara.id/register?ref=CJWVMGPR",
+		"tags": ["AI", "AI Credits", "API"],
+		"featured": false,
+		"status": "active"
 	}
 ]


### PR DESCRIPTION
Auto-generated from #155.

## Summary
- Add Claim 7M token free to the bansos list.
- Source payload comes from the contributor issue.

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Bynara promotional offer to the available benefits list, including free token rewards and related eligible-user benefits, with support for the existing signup/login and referral CTA flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->