### PR TITLE
chore(data): mark jagoanhosting-free-domain-webid as expired

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1266,7 +1266,7 @@
 		"ctaLink": "https://www.jagoanhosting.com",
 		"tags": ["Domain"],
 		"featured": false,
-		"status": "active"
+		"status": "expired"
 	},
 	{
 		"id": "adobe-creative-cloud-pro-trial",


### PR DESCRIPTION
Update status **Jagoan Hosting — Free Domain .WEB.ID** dari  jadi .\n\n🔗 https://bansos.dev/list/jagoanhosting-free-domain-webid/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated one promotion listing to show as expired instead of active, so the current status is displayed more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->