### PR TITLE
Tambah bansos: Free $5 Credit in Opencode GO - Refferal links

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1392,8 +1392,8 @@
 		"status": "active"
 	},
 	{
-\t\t"id": "opencode-go-free-5-credit",
-\t\t"title": "Free $5 Credit in Opencode GO - Referral links",
+		"id": "opencode-go-free-5-credit",
+		"title": "Free $5 Credit in Opencode GO - Referral links",
 		"provider": "Opencode Go",
 		"description": "Subscribe ke opencode go ai untuk mendapatkan free $5 melalui akun kamu",
 		"benefits": ["Free $5 Credit"],

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1390,5 +1390,25 @@
 		"tags": ["AI Credits", "Gratisan", "AI"],
 		"featured": false,
 		"status": "active"
+	},
+	{
+		"id": "f",
+		"title": "Free $5 Credit in Opencode GO - Refferal links",
+		"provider": "Opencode Go",
+		"description": "Subscribe ke opencode go ai untuk mendapatkan free $5 melalui akun kamu",
+		"benefits": ["Free $5 Credit"],
+		"validity": {
+			"type": "forever"
+		},
+		"requirements": ["Subscribe Opencode AI"],
+		"publishedAt": "2026-06-24",
+		"contributor": {
+			"name": "QRocket-Lab",
+			"url": "https://github.com/Qrocket-lab"
+		},
+		"ctaLink": "https://opencode.ai/go?ref=YCFKG306YB",
+		"tags": ["AI Credits", "AI", "API", "Promo"],
+		"featured": false,
+		"status": "active"
 	}
 ]

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -1392,8 +1392,8 @@
 		"status": "active"
 	},
 	{
-		"id": "f",
-		"title": "Free $5 Credit in Opencode GO - Refferal links",
+\t\t"id": "opencode-go-free-5-credit",
+\t\t"title": "Free $5 Credit in Opencode GO - Referral links",
 		"provider": "Opencode Go",
 		"description": "Subscribe ke opencode go ai untuk mendapatkan free $5 melalui akun kamu",
 		"benefits": ["Free $5 Credit"],


### PR DESCRIPTION
Auto-generated from #162.

## Summary
- Add Free $5 Credit in Opencode GO - Refferal links to the bansos list.
- Source payload comes from the contributor issue.

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new promotional/bansos entry with updated details, benefits, eligibility requirements, and an active call-to-action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->