### PR TITLE
fix: show all commit contributors on home page

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -45,7 +45,7 @@
 	const activeBansos = bansosList.filter((item) => item.status === 'active').length;
 	const upcomingBansos = bansosList.filter((item) => item.status === 'upcoming').length;
 	const expiredBansos = bansosList.filter((item) => item.status === 'expired').length;
-	const commitContributors = getCommitContributorStats().slice(0, 8);
+	const commitContributors = getCommitContributorStats();
 	let githubStars: number | string = $state('-');
 	let githubPrs: number | string = $state('-');
 	let githubContributors: GithubContributor[] = $state([]);


### PR DESCRIPTION
Remove `slice(0, 8)` limit so all 16 commit contributors are displayed on the home page instead of only top 8.

**Before:** 8 contributors shown
**After:** All 16 contributors shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Commit contributors” section now shows the full contributor list instead of limiting the display to the first few entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->