### PR TITLE
fix(mobile): contributors + github-actions + semua kontributor

### DIFF
--- a/src/lib/data/commit-contributors.json
+++ b/src/lib/data/commit-contributors.json
@@ -19,6 +19,12 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8105e48b0a6e5449d1fff3829b5968b02d84cdca4"
+		},
+		{
+			"login": "github-actions[bot]",
+			"name": "github-actions[bot]",
+			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/d279ea9e10c36b878f99c47ce28b4d6a0b8c9d01"
 		}
 	],
 	"agentrouter-free-250-ai-credit": [
@@ -27,6 +33,12 @@
 			"name": "vian0001",
 			"avatarUrl": "https://github.com/vian0001.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=vian0001"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/582c0166d0d2f7a9cffce572e640a2f9d316ed97"
 		}
 	],
 	"agentrouter-free-credits": [
@@ -35,6 +47,12 @@
 			"name": "Adefebrian",
 			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/fabff0303b704398757e341fbf819cd58ecd78aa"
 		}
 	],
 	"aiclass-asean-courses": [
@@ -51,14 +69,26 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"atomesus-free-1-year-subscription": [
 		{
-			"login": "Alfian57",
+			"login": "alfian57",
 			"name": "Alfian57",
 			"avatarUrl": "https://github.com/Alfian57.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Alfian57"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e2a09f76f361d9a10bd5a6d2c175bd8320be9ff5"
 		}
 	],
 	"aws-activate-credits": [
@@ -67,6 +97,20 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+		}
+	],
+	"claim-7m-token-free": [
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/e76ec2c5e5e6a1b9ae344d22de1ec7377ae2b96a"
 		}
 	],
 	"codecrafters-free-token": [
@@ -111,6 +155,36 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+		}
+	],
+	"diskon-free-hosting": [
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/1157999e5dd65910aa60af5c6510bb7f024a4c12"
+		}
+	],
+	"freemodel-pro-plan-bonus-referral-ikan": [
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/18dbc0c0f9a10fae58260ef016a8f17bfa75d442"
+		}
+	],
+	"freemodeldev-pro-plan-10-5-jam-70minggu-bonus-referral-10": [
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/d7f01545979c48852f7c28407178915d441faec8"
 		}
 	],
 	"gemini-plus-3bulan-sim": [
@@ -133,6 +207,12 @@
 			"name": "wauputr4",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/0f58ce2b1fa0a25d8d14434565519f69d4bd5628"
+		},
+		{
+			"login": "github-actions[bot]",
+			"name": "github-actions[bot]",
+			"avatarUrl": "https://github.com/github-actions[bot].png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/1abf005d93fb0d9d50189b09f70e16b841865958"
 		}
 	],
 	"google-startups-cloud": [
@@ -141,6 +221,12 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"gumloop-free-credits": [
@@ -149,6 +235,12 @@
 			"name": "Adefebrian",
 			"avatarUrl": "https://github.com/Adefebrian.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=Adefebrian"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/7abb4b6ea2117c96a9b07493ef48e976d9ac6160"
 		}
 	],
 	"idwebhost-domain-gratis-1tahun": [
@@ -157,6 +249,12 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e88f4b9151a8ad412aebefcb64a783f6437cb349"
+		},
+		{
+			"login": "renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/0ca2b156a3f1222687071ea265155f8df1c01d64"
 		}
 	],
 	"inceptionlabs-get-started": [
@@ -171,6 +269,20 @@
 			"name": "Wauputra",
 			"avatarUrl": "https://github.com/wauputr4.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
+		}
+	],
+	"jagoanhosting-free-domain-webid": [
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/071ec5abb889acdabdf32c893b0de73fc1dc8583"
+		},
+		{
+			"login": "risal1107",
+			"name": "risal1107",
+			"avatarUrl": "https://github.com/risal1107.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/96890e6748a7cf29370c61836b6e62a567637452"
 		}
 	],
 	"kie-ai-api-discount-credit": [
@@ -201,12 +313,32 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/e800c501c507145bc29c90b6c833e23bf788ebd7"
 		}
 	],
+	"merlin-ai-free-pro-1-month": [
+		{
+			"login": "renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/99f247e8bca8a2a8b08b5e11ae2ffb6e42470339"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=wauputr4"
+		}
+	],
 	"microsoft-founders-hub": [
 		{
 			"login": "renzie2161",
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"mongodb-startups": [
@@ -215,6 +347,12 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"namecheap-hosting-trial": [
@@ -223,6 +361,12 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/f264304560e07b2e7e58b1e37915227d2b1ee21a"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"namecheap-vps-hosting": [
@@ -247,6 +391,14 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/a53c64cdefcae865d843ec6b05fff598b03ccfee"
 		}
 	],
+	"neosantara-ai-gateway-bonus-rp-20000-kredit-rp-10000-bulan": [
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/f5598aba114c814728d86f1b137b7d0d9c116dc3"
+		}
+	],
 	"notion-ai-unlimited-1-bulan": [
 		{
 			"login": "wauputr4",
@@ -255,12 +407,40 @@
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/b82404464f3ef8662aa1736ab35d173f3b45eefd"
 		}
 	],
+	"openmodel-deepseek-v4-flash-free": [
+		{
+			"login": "renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/31af1e4a08784c119231e75d2d9b74041a5f07ae"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=wauputr4"
+		}
+	],
+	"openmodel-deepseek-v4-flash-free-access": [
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/61d86bf2a5b48c24e80d47599dfe9154e733a872"
+		}
+	],
 	"qoder-qwen-max-free": [
 		{
 			"login": "renzie2161",
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/b2c52d151481cf939939b2cd211a6c6f69f3507d"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"rumahweb-free-domain-xyz": [
@@ -269,6 +449,26 @@
 			"name": "inirey",
 			"avatarUrl": "https://github.com/inirey.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=inirey"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/63e6e769aa4cb9d84524733cc0648d02cebf33dd"
+		}
+	],
+	"servernusa-free-xiaomi-mimo": [
+		{
+			"login": "renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/09cdc6cf06088fd26c1c14fa57fd401c10f7196e"
+		},
+		{
+			"login": "wauputr4",
+			"name": "wauputr4",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=wauputr4"
 		}
 	],
 	"subdomain-gratis-permanen-untuk-developer-pelajar-dari-digitalplat": [
@@ -277,6 +477,26 @@
 			"name": "fazaimron27",
 			"avatarUrl": "https://github.com/fazaimron27.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=fazaimron27"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/ea8cc9d8295abb15223cc5ad15d40cd817b25220"
+		}
+	],
+	"sumopod-domain-rp1": [
+		{
+			"login": "renzie2161",
+			"name": "Renzie2161",
+			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/384d22a87de9577369d639455fe4a590a3e27df7"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"tokenrouter-minimax-m3-free": [
@@ -285,6 +505,12 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8389c12d14e04ae8109e74f705084e7443bd987f"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"tokenrouter-model-gateway": [
@@ -307,6 +533,12 @@
 			"name": "bang-joe",
 			"avatarUrl": "https://github.com/bang-joe.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=bang-joe"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/91825af921db233219c2d05d852b9458a1657ac8"
 		}
 	],
 	"xai-grok-api-credits": [
@@ -315,6 +547,12 @@
 			"name": "Renzie2161",
 			"avatarUrl": "https://github.com/Renzie2161.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commit/8f6d1ff1f0ec806965e7d90c2ff3a51f99045b24"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 		}
 	],
 	"xiaomi-mimo-gratis-2": [
@@ -323,6 +561,12 @@
 			"name": "muhakbarcom",
 			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/a47c50b332c6a2663fc24fe78d59c34138b8c717"
 		}
 	],
 	"zcode-glm-52-free": [
@@ -339,6 +583,12 @@
 			"name": "muhakbarcom",
 			"avatarUrl": "https://github.com/muhakbarcom.png?size=96",
 			"commitUrl": "https://github.com/wauputr4/bansos/commits?author=muhakbarcom"
+		},
+		{
+			"login": "wauputr4",
+			"name": "Wauputra",
+			"avatarUrl": "https://github.com/wauputr4.png?size=96",
+			"commitUrl": "https://github.com/wauputr4/bansos/commit/82ef68b090ebbb99b7cbeedb01746a463a51b14d"
 		}
 	]
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
 		latestBansos,
 		featuredBansos,
 		getCommitContributorStats,
+		getContributorStats,
 		formatNumber
 	} from '$lib/data/bansos';
 
@@ -45,7 +46,27 @@
 	const activeBansos = bansosList.filter((item) => item.status === 'active').length;
 	const upcomingBansos = bansosList.filter((item) => item.status === 'upcoming').length;
 	const expiredBansos = bansosList.filter((item) => item.status === 'expired').length;
-	const commitContributors = getCommitContributorStats();
+	const commitContributors = getCommitContributorStats()
+		.filter((c) => c.login !== 'github-actions[bot]');
+	// Gabungin dengan kontributor dari bansos.json (entry contributor field)
+	const entryContributors = getContributorStats();
+	const combinedLogins = new Set(commitContributors.map((c) => c.login.toLowerCase()));
+	for (const ec of entryContributors) {
+		const githubMatch = ec.url.match(new RegExp('^https://github.com/([^/?#]+)'));
+		if (githubMatch) {
+			const ghLogin = githubMatch[1].toLowerCase();
+			if (!combinedLogins.has(ghLogin)) {
+				combinedLogins.add(ghLogin);
+				commitContributors.push({
+					login: ghLogin,
+					name: ec.name,
+					avatarUrl: `https://github.com/${ghLogin}.png?size=96`,
+					commitUrl: `https://github.com/${ghLogin}`,
+					count: ec.count
+				});
+			}
+		}
+	}
 	let githubStars: number | string = $state('-');
 	let githubPrs: number | string = $state('-');
 	let githubContributors: GithubContributor[] = $state([]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -46,17 +46,21 @@
 	const activeBansos = bansosList.filter((item) => item.status === 'active').length;
 	const upcomingBansos = bansosList.filter((item) => item.status === 'upcoming').length;
 	const expiredBansos = bansosList.filter((item) => item.status === 'expired').length;
-	const commitContributors = getCommitContributorStats()
-		.filter((c) => c.login !== 'github-actions[bot]');
+	const commitContributors = getCommitContributorStats().filter(
+		(c) => c.login !== 'github-actions[bot]'
+	);
 	// Gabungin dengan kontributor dari bansos.json (entry contributor field)
 	const entryContributors = getContributorStats();
-	const combinedLogins = new Set(commitContributors.map((c) => c.login.toLowerCase()));
+	const combinedLogins: Record<string, boolean> = {};
+	for (const c of commitContributors) {
+		combinedLogins[c.login.toLowerCase()] = true;
+	}
 	for (const ec of entryContributors) {
 		const githubMatch = ec.url.match(new RegExp('^https://github.com/([^/?#]+)'));
 		if (githubMatch) {
 			const ghLogin = githubMatch[1].toLowerCase();
-			if (!combinedLogins.has(ghLogin)) {
-				combinedLogins.add(ghLogin);
+			if (!combinedLogins[ghLogin]) {
+				combinedLogins[ghLogin] = true;
 				commitContributors.push({
 					login: ghLogin,
 					name: ec.name,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -816,7 +816,15 @@
 
 	.github-actions {
 		display: flex;
+		flex-direction: row;
 		gap: 1rem;
+	}
+
+	@media (max-width: 48rem) {
+		.github-actions {
+			flex-direction: column;
+			align-items: center;
+		}
 	}
 
 	.repo-live-panel {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -45,7 +45,7 @@
 	const activeBansos = bansosList.filter((item) => item.status === 'active').length;
 	const upcomingBansos = bansosList.filter((item) => item.status === 'upcoming').length;
 	const expiredBansos = bansosList.filter((item) => item.status === 'expired').length;
-	const commitContributors = getCommitContributorStats().slice(0, 8);
+	const commitContributors = getCommitContributorStats();
 	let githubStars: number | string = $state('-');
 	let githubPrs: number | string = $state('-');
 	let githubContributors: GithubContributor[] = $state([]);
@@ -386,16 +386,18 @@
 			<div class="repo-live-panel" aria-label="Statistik repository GitHub bansos.dev">
 				<div class="commit-contributor-panel">
 					<span class="repo-panel-label">Commit kontributor</span>
-					<div class="contributors-stack" aria-label="Commit kontributor bansos data">
+					<div class="contributors-list" aria-label="Commit kontributor bansos data">
 						{#each commitContributors as contributor (contributor.login)}
 							<a
 								href={`https://github.com/${contributor.login}`}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="contributor-avatar"
+								class="contributor-row"
 								aria-label={`${contributor.login}, ${contributor.count} commit kontribusi`}
 							>
 								<img src={contributor.avatarUrl} alt={contributor.login} loading="lazy" />
+								<span class="contributor-login">{contributor.login}</span>
+								<span class="contributor-commit-count">{contributor.count}</span>
 							</a>
 						{/each}
 					</div>
@@ -848,39 +850,54 @@
 		text-transform: uppercase;
 	}
 
-	.contributors-stack {
+	.contributors-list {
 		display: flex;
-		justify-content: center;
-		padding-left: 0.75rem;
-	}
-
-	.contributor-avatar {
-		width: 2.35rem;
-		height: 2.35rem;
-		margin-left: -0.75rem;
-		border: 2px solid var(--bg-primary);
-		border-radius: 999px;
-		background: color-mix(in srgb, var(--text-primary) 8%, transparent);
-		box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
-	}
-
-	.contributor-avatar {
-		overflow: hidden;
-		transition:
-			transform 0.2s ease,
-			border-color 0.2s ease;
-	}
-
-	.contributor-avatar:hover {
-		transform: translateY(-2px);
-		border-color: rgba(16, 185, 129, 0.8);
-	}
-
-	.contributor-avatar img {
+		flex-direction: column;
+		gap: 0.5rem;
 		width: 100%;
-		height: 100%;
+		align-items: stretch;
+	}
+
+	.contributor-row {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+		padding: 0.45rem 0.65rem;
+		border-radius: 0.65rem;
+		color: var(--text-primary);
+		text-decoration: none;
+		transition: background-color 0.2s ease;
+	}
+
+	.contributor-row:hover {
+		background: color-mix(in srgb, var(--text-primary) 6%, transparent);
+		text-decoration: none;
+	}
+
+	.contributor-row img {
+		width: 2rem;
+		height: 2rem;
+		border-radius: 999px;
 		object-fit: cover;
-		display: block;
+		border: 2px solid var(--border-color);
+		flex-shrink: 0;
+	}
+
+	.contributor-login {
+		font-size: 0.88rem;
+		font-weight: 700;
+		margin-right: auto;
+	}
+
+	.contributor-commit-count {
+		font-size: 0.8rem;
+		font-weight: 750;
+		color: var(--text-secondary);
+		background: color-mix(in srgb, var(--text-primary) 6%, transparent);
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		white-space: nowrap;
+		flex-shrink: 0;
 	}
 
 	.repo-live-stats {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -386,18 +386,16 @@
 			<div class="repo-live-panel" aria-label="Statistik repository GitHub bansos.dev">
 				<div class="commit-contributor-panel">
 					<span class="repo-panel-label">Commit kontributor</span>
-					<div class="contributors-list" aria-label="Commit kontributor bansos data">
+					<div class="contributors-stack" aria-label="Commit kontributor bansos data">
 						{#each commitContributors as contributor (contributor.login)}
 							<a
 								href={`https://github.com/${contributor.login}`}
 								target="_blank"
 								rel="noopener noreferrer"
-								class="contributor-row"
+								class="contributor-avatar"
 								aria-label={`${contributor.login}, ${contributor.count} commit kontribusi`}
 							>
 								<img src={contributor.avatarUrl} alt={contributor.login} loading="lazy" />
-								<span class="contributor-login">{contributor.login}</span>
-								<span class="contributor-commit-count">{contributor.count}</span>
 							</a>
 						{/each}
 					</div>
@@ -850,54 +848,38 @@
 		text-transform: uppercase;
 	}
 
-	.contributors-list {
+	.contributors-stack {
 		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
+		flex-wrap: wrap;
+		justify-content: center;
+		padding-left: 0.75rem;
+		gap: 0;
+	}
+
+	.contributor-avatar {
+		width: 2.35rem;
+		height: 2.35rem;
+		margin-left: -0.75rem;
+		border: 2px solid var(--bg-primary);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--text-primary) 8%, transparent);
+		box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+		overflow: hidden;
+		transition:
+			transform 0.2s ease,
+			border-color 0.2s ease;
+	}
+
+	.contributor-avatar:hover {
+		transform: translateY(-2px);
+		border-color: rgba(16, 185, 129, 0.8);
+	}
+
+	.contributor-avatar img {
 		width: 100%;
-		align-items: stretch;
-	}
-
-	.contributor-row {
-		display: flex;
-		align-items: center;
-		gap: 0.65rem;
-		padding: 0.45rem 0.65rem;
-		border-radius: 0.65rem;
-		color: var(--text-primary);
-		text-decoration: none;
-		transition: background-color 0.2s ease;
-	}
-
-	.contributor-row:hover {
-		background: color-mix(in srgb, var(--text-primary) 6%, transparent);
-		text-decoration: none;
-	}
-
-	.contributor-row img {
-		width: 2rem;
-		height: 2rem;
-		border-radius: 999px;
+		height: 100%;
 		object-fit: cover;
-		border: 2px solid var(--border-color);
-		flex-shrink: 0;
-	}
-
-	.contributor-login {
-		font-size: 0.88rem;
-		font-weight: 700;
-		margin-right: auto;
-	}
-
-	.contributor-commit-count {
-		font-size: 0.8rem;
-		font-weight: 750;
-		color: var(--text-secondary);
-		background: color-mix(in srgb, var(--text-primary) 6%, transparent);
-		padding: 0.15rem 0.55rem;
-		border-radius: 999px;
-		white-space: nowrap;
-		flex-shrink: 0;
+		display: block;
 	}
 
 	.repo-live-stats {


### PR DESCRIPTION
## Perbaikan Mobile Layout bansos.dev

### 1. Semua kontributor muncul (16 orang) 👥
- **Sebelum:** cuma 11 kontributor dari commit-contributors.json, dibatesin 8
- **Sesudah:** gabungin dari 2 sumber (commit-contributors.json + bansos.json contributor field) = **16 kontributor**
- Skip github-actions[bot]
- Avatar stack pake `flex-wrap: wrap` — kalo penuh lanjut baris bawah

### 2. github-actions — stack vertikal di mobile
- Tombol Kontribusi & Selengkapnya jadi `flex-column` pas viewport <48rem

### Verifikasi
- ✅ 16 kontributor muncul (cek pake Playwright)
- ✅ Build passing
- ✅ No overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the GitHub Actions section layout with explicit row layout on larger screens and a centered vertical stack on smaller screens.
  * Updated the contributors avatar stack to support wrapping and tightened spacing between avatars.
  * Fixed contributor avatar styling so hover/overflow/transition behavior applies consistently.

* **Bug Fixes**
  * Updated contributor rendering to use the complete contributor stats, exclude GitHub Actions bot, deduplicate logins case-insensitively, and enrich each contributor with derived fields.

* **Chores**
  * Refreshed the contributors data set, including added contributors and updated contributor URLs/names across multiple entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->