### PR TITLE
Add/tencent cloud free tier

### DIFF
--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -2479,5 +2479,42 @@
     ],
     "featured": false,
     "status": "active"
+  },
+  {
+    "id": "tencent-cloud-free-tier",
+    "title": "Tencent Cloud Free Tier (Trial Gratis 30+ Produk)",
+    "provider": "Tencent Cloud",
+    "description": "Tencent Cloud menyediakan free trial untuk lebih dari 30 produk cloud, termasuk komputasi, storage, jaringan, komunikasi real-time, dan layanan AI.",
+    "benefits": [
+      "Lighthouse 2C2G gratis selama 3 bulan",
+      "Cloud Virtual Machine 2C4G gratis selama 3 bulan",
+      "Cloud Object Storage 50GB gratis selama 6 bulan",
+      "TRTC 10.000 menit gratis setiap bulan",
+      "EdgeOne gratis selama 14 hari",
+      "Tencent Hunyuan 3D 200 kredit gratis selama 1 tahun"
+    ],
+    "validity": {
+      "type": "uncertain",
+      "description": "Durasi dan kuota berbeda untuk setiap produk. Trial hanya tersedia bagi pengguna baru produk terkait dan mengikuti aturan resmi Tencent Cloud."
+    },
+    "requirements": [
+      "Buat atau masuk ke akun Tencent Cloud",
+      "Selesaikan verifikasi akun",
+      "Belum pernah menggunakan atau mencoba produk Tencent Cloud terkait",
+      "Periksa konfigurasi trial dan aturan produk sebelum mengaktifkan"
+    ],
+    "publishedAt": "2026-07-22",
+    "source": "https://www.tencentcloud.com/act/pro/FreeTier",
+    "contributor": {
+      "name": "superftch",
+      "url": "https://github.com/superftch"
+    },
+    "ctaLink": "https://www.tencentcloud.com/act/pro/FreeTier",
+    "tags": [
+      "Cloud Services",
+      "Free Tier"
+    ],
+    "featured": false,
+    "status": "active"
   }
 ]

--- a/src/lib/data/bansos.json
+++ b/src/lib/data/bansos.json
@@ -2512,7 +2512,9 @@
     "ctaLink": "https://www.tencentcloud.com/act/pro/FreeTier",
     "tags": [
       "Cloud Services",
-      "Free Tier"
+      "Free Tier",
+      "VPS & Server",
+      "Hosting"
     ],
     "featured": false,
     "status": "active"


### PR DESCRIPTION
## Summary

- Add Tencent Cloud Free Tier as a new umbrella listing.
- Include Lighthouse, CVM, COS, TRTC, EdgeOne, and Hunyuan 3D trial benefits.
- Add eligibility requirements, official source, contributor metadata, and relevant tags.

## Verification

- `npm run check` passed with 0 errors and 0 warnings.
- Data-only change in `src/lib/data/bansos.json`.
- Official source: https://www.tencentcloud.com/act/pro/FreeTier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new active promotion for Tencent Cloud’s free tier, offering trials of more than 30 products.
  * Included eligibility requirements, validity details, benefits, and a link to access the offer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->