### PR TITLE
feat: add SITEQU domain payday promo

### DIFF
--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -284,6 +284,11 @@
 		"date": "2026-06-23T09:48:25+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/61d86bf2a5b48c24e80d47599dfe9154e733a872"
 	},
+	"promo-domain-sitequ": {
+		"hash": "6bcf9266c7b9bc2220eeb4566e84996dbe6f4444",
+		"date": "2026-07-23T17:24:42+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/6bcf9266c7b9bc2220eeb4566e84996dbe6f4444"
+	},
 	"qoder-qwen-max-free": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",

--- a/src/lib/data/bansos/contributors/sitequ-digital-indonesia/README.md
+++ b/src/lib/data/bansos/contributors/sitequ-digital-indonesia/README.md
@@ -1,0 +1,3 @@
+# SITEQU DIGITAL INDONESIA
+
+Kontributor komunitas [bansos.dev](https://bansos.dev).

--- a/src/lib/data/bansos/contributors/sitequ-digital-indonesia/manifest.json
+++ b/src/lib/data/bansos/contributors/sitequ-digital-indonesia/manifest.json
@@ -1,0 +1,13 @@
+{
+	"login": "sitequ-digital-indonesia",
+	"displayName": "SITEQU DIGITAL INDONESIA",
+	"bio": "",
+	"title": "",
+	"skills": [],
+	"links": {
+		"website": "https://domain.sitequ.id/"
+	},
+	"contributedBansos": ["promo-domain-sitequ"],
+	"hidden": false,
+	"joinedAt": "2026-07-23"
+}

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-07-23",
-	"total": 76,
+	"total": 77,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -588,6 +588,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-23",
 			"contributorSlug": "syafrie-yunizar"
+		},
+		{
+			"id": "promo-domain-sitequ",
+			"title": "Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp3.500",
+			"provider": "SITEQU Digital Indonesia",
+			"status": "active",
+			"tags": ["Domain", "Diskon"],
+			"featured": true,
+			"publishedAt": "2026-07-23",
+			"contributorSlug": "sitequ-digital-indonesia"
 		},
 		{
 			"id": "qoder-qwen-max-free",

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -595,7 +595,7 @@
 			"provider": "SITEQU Digital Indonesia",
 			"status": "active",
 			"tags": ["Domain", "Diskon"],
-			"featured": true,
+			"featured": false,
 			"publishedAt": "2026-07-23",
 			"contributorSlug": "sitequ-digital-indonesia"
 		},

--- a/src/lib/data/bansos/promo-domain-sitequ/README.md
+++ b/src/lib/data/bansos/promo-domain-sitequ/README.md
@@ -1,0 +1,39 @@
+# ✅ Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp3.500
+
+**Provider:** SITEQU Digital Indonesia
+
+Promo pendaftaran domain Indonesia .MY.ID, .BIZ.ID, dan .WEB.ID seharga Rp3.500 selama periode Gajian Sale SITEQU Digital Indonesia.
+
+> **Status:** Aktif
+
+⏰ **Berlaku sampai:** 2026-07-31
+
+## Keuntungan
+
+- Pendaftaran domain .MY.ID seharga Rp3.500
+- Pendaftaran domain .BIZ.ID seharga Rp3.500
+- Pendaftaran domain .WEB.ID seharga Rp3.500
+- Harga promo diterapkan otomatis tanpa kode voucher
+
+## Persyaratan
+
+- Pilih domain .MY.ID, .BIZ.ID, atau .WEB.ID yang masih tersedia
+- Lakukan pendaftaran melalui situs resmi SITEQU selama periode promo
+- Ikuti syarat pendaftaran domain Indonesia dari provider
+
+## Tips
+
+Promo berlaku untuk pendaftaran baru. Harga perpanjangan dan transfer tetap mengikuti tarif normal yang tampil saat checkout.
+
+---
+
+[🔗 Klaim Bansos Ini](https://domain.sitequ.id/)
+
+
+🏷️ Tags: Domain · Diskon
+
+✏️ Dikontribusikan oleh `sitequ-digital-indonesia`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/promo-domain-sitequ/index.json
+++ b/src/lib/data/bansos/promo-domain-sitequ/index.json
@@ -22,7 +22,7 @@
 	"ctaLink": "https://domain.sitequ.id/",
 	"tags": ["Domain", "Diskon"],
 	"status": "active",
-	"featured": true,
+	"featured": false,
 	"publishedAt": "2026-07-23",
 	"tips": "Promo berlaku untuk pendaftaran baru. Harga perpanjangan dan transfer tetap mengikuti tarif normal yang tampil saat checkout.",
 	"source": "https://domain.sitequ.id/",

--- a/src/lib/data/bansos/promo-domain-sitequ/index.json
+++ b/src/lib/data/bansos/promo-domain-sitequ/index.json
@@ -1,0 +1,30 @@
+{
+	"id": "promo-domain-sitequ",
+	"title": "Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp3.500",
+	"provider": "SITEQU Digital Indonesia",
+	"description": "Promo pendaftaran domain Indonesia .MY.ID, .BIZ.ID, dan .WEB.ID seharga Rp3.500 selama periode Gajian Sale SITEQU Digital Indonesia.",
+	"benefits": [
+		"Pendaftaran domain .MY.ID seharga Rp3.500",
+		"Pendaftaran domain .BIZ.ID seharga Rp3.500",
+		"Pendaftaran domain .WEB.ID seharga Rp3.500",
+		"Harga promo diterapkan otomatis tanpa kode voucher"
+	],
+	"validity": {
+		"type": "fixed",
+		"date": "2026-07-31",
+		"description": "Berlaku sampai 31 Juli 2026 atau selama kuota promo tersedia"
+	},
+	"requirements": [
+		"Pilih domain .MY.ID, .BIZ.ID, atau .WEB.ID yang masih tersedia",
+		"Lakukan pendaftaran melalui situs resmi SITEQU selama periode promo",
+		"Ikuti syarat pendaftaran domain Indonesia dari provider"
+	],
+	"ctaLink": "https://domain.sitequ.id/",
+	"tags": ["Domain", "Diskon"],
+	"status": "active",
+	"featured": true,
+	"publishedAt": "2026-07-23",
+	"tips": "Promo berlaku untuk pendaftaran baru. Harga perpanjangan dan transfer tetap mengikuti tarif normal yang tampil saat checkout.",
+	"source": "https://domain.sitequ.id/",
+	"contributorSlug": "sitequ-digital-indonesia"
+}


### PR DESCRIPTION
## Ringkasan

- menambahkan promo pendaftaran `.MY.ID`, `.BIZ.ID`, dan `.WEB.ID` Rp3.500 dari SITEQU
- menambahkan profil contributor SITEQU Digital Indonesia
- memperbarui catalog index dan commit history

## Verifikasi

- halaman resmi menampilkan harga pendaftaran Rp3.500 untuk ketiga ekstensi
- promo diterapkan otomatis tanpa kode voucher
- renewal dan transfer tetap harga normal; sudah ditegaskan pada tips
- valid sampai 31 Juli 2026 atau selama kuota tersedia
- `featured: true` karena promo terbatas dan diskonnya signifikan

## Checks

- `npm run check`
- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new active SITEQU Digital Indonesia promotion for `.MY.ID`, `.BIZ.ID`, and `.WEB.ID` domains at Rp3.500.
  * Included promotion details, benefits, requirements, validity through July 31, 2026, and a claim link.
  * Added contributor information and attribution for the new listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->