### PR TITLE
feat(bansos): tambah GoRouter Free $75 AI Credit

### DIFF
--- a/src/lib/data/bansos/contributors/rafly0078/README.md
+++ b/src/lib/data/bansos/contributors/rafly0078/README.md
@@ -1,0 +1,3 @@
+# Rafly0078
+
+Kontributor komunitas [bansos.dev](https://bansos.dev).

--- a/src/lib/data/bansos/contributors/rafly0078/manifest.json
+++ b/src/lib/data/bansos/contributors/rafly0078/manifest.json
@@ -1,0 +1,13 @@
+{
+	"login": "rafly0078",
+	"displayName": "Rafly0078",
+	"bio": "",
+	"title": "",
+	"skills": [],
+	"links": {
+		"github": "https://github.com/Rafly0078"
+	},
+	"contributedBansos": ["gorouter-free-75-ai-credit"],
+	"hidden": false,
+	"joinedAt": "2026-07-29"
+}

--- a/src/lib/data/bansos/gorouter-free-75-ai-credit/README.md
+++ b/src/lib/data/bansos/gorouter-free-75-ai-credit/README.md
@@ -1,0 +1,35 @@
+# ✅ GoRouter Free $75 AI Credit
+
+**Provider:** GoRouter
+
+GoRouter memberikan kredit API senilai $75 untuk pengguna baru yang login menggunakan akun GitHub. Kredit dapat dipakai untuk mengakses model Claude Opus 4.8 dan Claude Opus 5.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Ketersediaan dan besaran kredit mengikuti kebijakan GoRouter
+
+## Keuntungan
+
+- Kredit API senilai $75 untuk pengguna baru
+- Bisa dipakai untuk model Claude Opus 4.8 dan Claude Opus 5
+- Login cukup dengan akun GitHub
+
+## Persyaratan
+
+- Login menggunakan akun GitHub
+- Umur akun GitHub minimal 1 bulan
+- Daftar melalui link yang tersedia
+- Cek saldo kredit di dashboard GoRouter
+
+---
+
+[🔗 Klaim Bansos Ini](https://gorouter.app/sign-up?aff=9hk5)
+
+
+🏷️ Tags: AI Credits · API · AI Tools · Free Tier · Developer Tools
+
+✏️ Dikontribusikan oleh `rafly0078`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/gorouter-free-75-ai-credit/index.json
+++ b/src/lib/data/bansos/gorouter-free-75-ai-credit/index.json
@@ -1,0 +1,28 @@
+{
+	"id": "gorouter-free-75-ai-credit",
+	"title": "GoRouter Free $75 AI Credit",
+	"provider": "GoRouter",
+	"description": "GoRouter memberikan kredit API senilai $75 untuk pengguna baru yang login menggunakan akun GitHub. Kredit dapat dipakai untuk mengakses model Claude Opus 4.8 dan Claude Opus 5.",
+	"benefits": [
+		"Kredit API senilai $75 untuk pengguna baru",
+		"Bisa dipakai untuk model Claude Opus 4.8 dan Claude Opus 5",
+		"Login cukup dengan akun GitHub"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Ketersediaan dan besaran kredit mengikuti kebijakan GoRouter"
+	},
+	"requirements": [
+		"Login menggunakan akun GitHub",
+		"Umur akun GitHub minimal 1 bulan",
+		"Daftar melalui link yang tersedia",
+		"Cek saldo kredit di dashboard GoRouter"
+	],
+	"ctaLink": "https://gorouter.app/sign-up?aff=9hk5",
+	"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-07-29",
+	"source": "https://gorouter.app/sign-up?aff=9hk5",
+	"contributorSlug": "rafly0078"
+}

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-07-23",
-	"total": 77,
+	"total": 78,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -319,6 +319,16 @@
 			"featured": true,
 			"publishedAt": "2026-06-13",
 			"contributorSlug": "devers"
+		},
+		{
+			"id": "gorouter-free-75-ai-credit",
+			"title": "GoRouter Free $75 AI Credit",
+			"provider": "GoRouter",
+			"status": "active",
+			"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+			"featured": false,
+			"publishedAt": "2026-07-29",
+			"contributorSlug": "rafly0078"
 		},
 		{
 			"id": "gumloop-free-credits",


### PR DESCRIPTION
Listing baru: kredit API $75 untuk pengguna baru GoRouter, bisa dipakai ke model Claude Opus 4.8 dan Claude Opus 5. Klaim lewat login GitHub dengan umur akun minimal 1 bulan. Validity uncertain karena provider tidak menyebut tanggal berakhir.

Menambahkan profil kontributor baru rafly0078.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the “GoRouter Free $75 AI Credit” offer to the catalog.
  - Included eligibility requirements, benefits, claim instructions, and relevant links.
  - Increased the catalog total to 78 available offers.
  - Added contributor attribution and profile information for rafly0078.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->