### PR TITLE
Revise promo details for .MY.ID, .BIZ.ID, .WEB.ID

### DIFF
--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -611,12 +611,12 @@
 		},
 		{
 			"id": "promo-domain-sitequ",
-			"title": "Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp3.500",
+			"title": "PROMO MENYAMBUT KEMERDEKAAN: Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp2.000",
 			"provider": "SITEQU Digital Indonesia",
 			"status": "active",
 			"tags": ["Domain", "Diskon"],
 			"featured": false,
-			"publishedAt": "2026-07-23",
+			"publishedAt": "2026-08-02",
 			"contributorSlug": "sitequ-digital-indonesia"
 		},
 		{

--- a/src/lib/data/bansos/promo-domain-sitequ/README.md
+++ b/src/lib/data/bansos/promo-domain-sitequ/README.md
@@ -1,4 +1,5 @@
-# ✅ Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp3.500
+# PROMO MENYAMBUT KEMERDEKAAN
+# ✅ Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp2.000
 
 **Provider:** SITEQU Digital Indonesia
 
@@ -6,13 +7,13 @@ Promo pendaftaran domain Indonesia .MY.ID, .BIZ.ID, dan .WEB.ID seharga Rp3.500 
 
 > **Status:** Aktif
 
-⏰ **Berlaku sampai:** 2026-07-31
+⏰ **Berlaku sampai:** 2026-08-31
 
 ## Keuntungan
 
-- Pendaftaran domain .MY.ID seharga Rp3.500
-- Pendaftaran domain .BIZ.ID seharga Rp3.500
-- Pendaftaran domain .WEB.ID seharga Rp3.500
+- Pendaftaran domain .MY.ID seharga Rp2.000
+- Pendaftaran domain .BIZ.ID seharga Rp2.000
+- Pendaftaran domain .WEB.ID seharga Rp2.000
 - Harga promo diterapkan otomatis tanpa kode voucher
 
 ## Persyaratan

--- a/src/lib/data/bansos/promo-domain-sitequ/README.md
+++ b/src/lib/data/bansos/promo-domain-sitequ/README.md
@@ -1,13 +1,12 @@
-# PROMO MENYAMBUT KEMERDEKAAN
-# ✅ Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp2.000
+# ✅ PROMO MENYAMBUT KEMERDEKAAN: Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp2.000
 
 **Provider:** SITEQU Digital Indonesia
 
-Promo pendaftaran domain Indonesia .MY.ID, .BIZ.ID, dan .WEB.ID seharga Rp3.500 selama periode Gajian Sale SITEQU Digital Indonesia.
+Promo pendaftaran domain Indonesia .MY.ID, .BIZ.ID, dan .WEB.ID seharga Rp2.000 selama periode promo SITEQU Digital Indonesia.
 
 > **Status:** Aktif
 
-⏰ **Berlaku sampai:** 2026-08-31
+⏰ **Info Waktu:** Provider saat ini menampilkan promo ini; batas akhir promo tidak tercantum di halaman sumber.
 
 ## Keuntungan
 

--- a/src/lib/data/bansos/promo-domain-sitequ/index.json
+++ b/src/lib/data/bansos/promo-domain-sitequ/index.json
@@ -1,18 +1,17 @@
 {
 	"id": "promo-domain-sitequ",
-	"title": "Promo Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp3.500",
+	"title": "PROMO MENYAMBUT KEMERDEKAAN: Domain .MY.ID, .BIZ.ID, dan .WEB.ID Rp2.000",
 	"provider": "SITEQU Digital Indonesia",
-	"description": "Promo pendaftaran domain Indonesia .MY.ID, .BIZ.ID, dan .WEB.ID seharga Rp3.500 selama periode Gajian Sale SITEQU Digital Indonesia.",
+	"description": "Promo pendaftaran domain Indonesia .MY.ID, .BIZ.ID, dan .WEB.ID seharga Rp2.000 selama periode promo SITEQU Digital Indonesia.",
 	"benefits": [
-		"Pendaftaran domain .MY.ID seharga Rp3.500",
-		"Pendaftaran domain .BIZ.ID seharga Rp3.500",
-		"Pendaftaran domain .WEB.ID seharga Rp3.500",
+		"Pendaftaran domain .MY.ID seharga Rp2.000",
+		"Pendaftaran domain .BIZ.ID seharga Rp2.000",
+		"Pendaftaran domain .WEB.ID seharga Rp2.000",
 		"Harga promo diterapkan otomatis tanpa kode voucher"
 	],
 	"validity": {
-		"type": "fixed",
-		"date": "2026-07-31",
-		"description": "Berlaku sampai 31 Juli 2026 atau selama kuota promo tersedia"
+		"type": "uncertain",
+		"description": "Provider saat ini menampilkan promo ini; batas akhir promo tidak tercantum di halaman sumber."
 	},
 	"requirements": [
 		"Pilih domain .MY.ID, .BIZ.ID, atau .WEB.ID yang masih tersedia",
@@ -23,7 +22,7 @@
 	"tags": ["Domain", "Diskon"],
 	"status": "active",
 	"featured": false,
-	"publishedAt": "2026-07-23",
+	"publishedAt": "2026-08-02",
 	"tips": "Promo berlaku untuk pendaftaran baru. Harga perpanjangan dan transfer tetap mengikuti tarif normal yang tampil saat checkout.",
 	"source": "https://domain.sitequ.id/",
 	"contributorSlug": "sitequ-digital-indonesia"


### PR DESCRIPTION
Updated promotional details for domain registration, including new pricing and expiration date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the SITEQU Digital Indonesia promotion price to Rp2.000 for `.MY.ID`, `.BIZ.ID`, and `.WEB.ID` domains.
  * Revised the promotion title, description, and listed benefits.
  * Updated the publication date to August 2, 2026.
  * Removed the previously stated end date; no deadline is currently listed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->