### PR TITLE
feat: tambah listing SeekAi Free $200 AI Credit

### DIFF
--- a/src/lib/data/bansos/contributors/syafii-fahreza/manifest.json
+++ b/src/lib/data/bansos/contributors/syafii-fahreza/manifest.json
@@ -10,6 +10,7 @@
 		"ai-hub-free-plan",
 		"futureppo-free-credit",
 		"modelset-free-credit",
+		"seekai-free-200-ai-credit",
 		"tokenfaucet-daily-free-tokens",
 		"vsllm-daily-checkin-rewards"
 	],

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-07-23",
-	"total": 78,
+	"total": 79,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -638,6 +638,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-18",
 			"contributorSlug": "rey"
+		},
+		{
+			"id": "seekai-free-200-ai-credit",
+			"title": "SeekAi Free $200 AI Credit",
+			"provider": "SeekAi",
+			"status": "active",
+			"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+			"featured": false,
+			"publishedAt": "2026-08-02",
+			"contributorSlug": "syafii-fahreza"
 		},
 		{
 			"id": "servernusa-free-xiaomi-mimo",

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
-	"generatedAt": "2026-07-23",
-	"total": 79,
+	"generatedAt": "2026-08-02",
+	"total": 80,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",

--- a/src/lib/data/bansos/seekai-free-200-ai-credit/README.md
+++ b/src/lib/data/bansos/seekai-free-200-ai-credit/README.md
@@ -1,0 +1,40 @@
+# ✅ SeekAi Free $200 AI Credit
+
+**Provider:** SeekAi
+
+SeekAi adalah gateway API terpadu yang menyatukan akses ke banyak model AI terkemuka lewat satu endpoint. Akun baru yang mendaftar memakai kode undangan mendapat kredit senilai $200 untuk memanggil model seperti Claude Opus 5, GPT-5.6, Gemini 3 Pro, DeepSeek V4, Grok 4.5, dan Qwen 3 Max. Layanan masih tahap beta dan gratis sepenuhnya, tetapi penyedia menyatakan data akun bisa dihapus saat versi resmi rilis.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Gratis selama masa beta; penyedia berencana mulai menarik biaya saat versi resmi rilis
+
+## Keuntungan
+
+- Kredit senilai $200 untuk akun baru yang mendaftar lewat kode undangan
+- Satu gateway untuk model Claude Opus 5, GPT-5.6, Gemini 3 Pro, DeepSeek V4, Grok 4.5, dan Qwen 3 Max
+- Gratis sepenuhnya selama masa beta, tanpa kartu kredit
+- Endpoint kompatibel OpenAI sehingga bisa dipakai dari Codex, Cline, dan tool sejenis
+
+## Persyaratan
+
+- Daftar lewat tautan undangan agar kredit $200 masuk ke akun
+- Verifikasi email saat pendaftaran, atau lanjutkan dengan akun GitHub
+- Setujui User Agreement saat membuat akun
+- Buat API key di menu Console sebelum mulai memanggil model
+
+## Tips
+
+Masih tahap beta dan beberapa kali dilaporkan tidak stabil, dengan batas sekitar 60 permintaan per menit per akun. Data akun berpotensi dihapus saat versi resmi rilis, jadi hindari memakainya untuk kebutuhan produksi.
+
+---
+
+[🔗 Klaim Bansos Ini](https://seekai.cc/sign-up?aff=vHYm)
+
+
+🏷️ Tags: AI Credits · API · AI Tools · Free Tier · Developer Tools
+
+✏️ Dikontribusikan oleh `syafii-fahreza`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/seekai-free-200-ai-credit/index.json
+++ b/src/lib/data/bansos/seekai-free-200-ai-credit/index.json
@@ -1,0 +1,30 @@
+{
+	"id": "seekai-free-200-ai-credit",
+	"title": "SeekAi Free $200 AI Credit",
+	"provider": "SeekAi",
+	"description": "SeekAi adalah gateway API terpadu yang menyatukan akses ke banyak model AI terkemuka lewat satu endpoint. Akun baru yang mendaftar memakai kode undangan mendapat kredit senilai $200 untuk memanggil model seperti Claude Opus 5, GPT-5.6, Gemini 3 Pro, DeepSeek V4, Grok 4.5, dan Qwen 3 Max. Layanan masih tahap beta dan gratis sepenuhnya, tetapi penyedia menyatakan data akun bisa dihapus saat versi resmi rilis.",
+	"benefits": [
+		"Kredit senilai $200 untuk akun baru yang mendaftar lewat kode undangan",
+		"Satu gateway untuk model Claude Opus 5, GPT-5.6, Gemini 3 Pro, DeepSeek V4, Grok 4.5, dan Qwen 3 Max",
+		"Gratis sepenuhnya selama masa beta, tanpa kartu kredit",
+		"Endpoint kompatibel OpenAI sehingga bisa dipakai dari Codex, Cline, dan tool sejenis"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Gratis selama masa beta; penyedia berencana mulai menarik biaya saat versi resmi rilis"
+	},
+	"requirements": [
+		"Daftar lewat tautan undangan agar kredit $200 masuk ke akun",
+		"Verifikasi email saat pendaftaran, atau lanjutkan dengan akun GitHub",
+		"Setujui User Agreement saat membuat akun",
+		"Buat API key di menu Console sebelum mulai memanggil model"
+	],
+	"ctaLink": "https://seekai.cc/sign-up?aff=vHYm",
+	"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-02",
+	"tips": "Masih tahap beta dan beberapa kali dilaporkan tidak stabil, dengan batas sekitar 60 permintaan per menit per akun. Data akun berpotensi dihapus saat versi resmi rilis, jadi hindari memakainya untuk kebutuhan produksi.",
+	"source": "https://t.me/ModelFreeApi/24",
+	"contributorSlug": "syafii-fahreza"
+}


### PR DESCRIPTION
## Ringkasan

Menambah satu listing baru: **SeekAi Free $200 AI Credit** (`seekai-free-200-ai-credit`).

SeekAi adalah gateway API terpadu (New API) yang menyatukan akses ke banyak model AI lewat satu endpoint kompatibel OpenAI. Akun baru yang mendaftar memakai kode undangan mendapat kredit senilai $200.

## Bukti sumber

- Pengumuman resmi provider: https://t.me/ModelFreeApi/24 — menyebut eksplisit *"Your friends will receive a $200 quota, and you will get a $20 quota"* dan *"The site is completely free to use during the beta test. Your user data may be cleared when the official version launches."*
- Landing/klaim: https://seekai.cc/sign-up?aff=vHYm (halaman pendaftaran aktif, verifikasi email + opsi GitHub OAuth)
- Situs resmi: https://seekai.cc

Model yang tersedia saat verifikasi: Claude Fable 5, Claude Opus 4.7/4.8/5, Claude Sonnet 5, DeepSeek V4 Flash/Pro, Gemini 3 Flash/Pro/3.1 Pro, GLM 5.2, GPT-5.4/5.5/5.6 (sol/terra/luna), Grok 4.5, Qwen 3 Max.

## Ketidakpastian yang saya sengaja cantumkan

`validity.type` saya set **`uncertain`**, bukan tanggal pasti, karena provider hanya menyatakan "gratis selama beta" tanpa tanggal akhir dan berencana menarik biaya saat versi resmi rilis.

Field `tips` memuat peringatan yang menurut saya perlu diketahui pengguna sebelum klaim:

- Masih tahap beta dan beberapa kali dilaporkan tidak stabil (channel resmi berisi laporan gangguan 31 Juli–1 Agustus 2026).
- Ada batas laju sekitar 60 permintaan per menit per akun.
- **Data akun berpotensi dihapus saat versi resmi rilis** — jadi tidak disarankan untuk kebutuhan produksi.

## Atribusi

`contributorSlug`: `syafii-fahreza` (profil sudah ada, hanya menambah ID listing ke `contributedBansos`). `ctaLink` memakai kode undangan kontributor sesuai § "Aturan referral" di `CONTRIBUTING.md`.

## Validasi yang dijalankan

| Perintah | Hasil |
|---|---|
| `npm run validate:data` | ✅ 80 folder + referensi kontributor valid |
| `prettier --check .` | ✅ seluruh repo lolos |
| `eslint .` | ✅ nol masalah |
| `svelte-check` | ✅ 0 error, 0 warning |

`npm run build` **tidak berhasil saya selesaikan di lingkungan lokal saya** (Android/Termux), tapi bukan karena perubahan ini — prerender berhenti di `404 /rafly/ (linked from /rafly)`. Penyebabnya ada di file generated `src/lib/data/bansos/commit-contributors.json` yang memuat author commit `"login": "rafly"`, sementara folder profil yang ada hanya `contributors/rafly0078/`. File itu gitignored dan tidak ikut dalam PR ini. Mungkin layak dicek terpisah oleh maintainer.

Perubahan PR ini murni data: satu folder listing baru, registrasi di katalog `index.json`, dan satu baris di manifest kontributor. Tidak ada perubahan UI, jadi tidak ada screenshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new active offer providing $200 in SeekAi AI credits.
  - Included eligibility requirements, supported models, usage limits, setup guidance, signup details, and beta stability notes.
  - Updated the available offer count from 78 to 79.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->