### PR TITLE
feat: add UpCloud free trial details

### DIFF
--- a/src/lib/data/bansos/contributors/wauputr4/manifest.json
+++ b/src/lib/data/bansos/contributors/wauputr4/manifest.json
@@ -22,6 +22,7 @@
 		"jagoanhosting-promo-vps-25",
 		"namecheap-vps-hosting",
 		"namecom-domain-app",
+		"upcloud-free-trial",
 		"zyloo-free-200-credit-post"
 	],
 	"hidden": false,

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -741,7 +741,7 @@
 		},
 		{
 			"id": "upcloud-free-trial",
-			"title": "UpCloud Free Trial 7 Hari untuk Cloud Server",
+			"title": "UpCloud Free Trial hingga 30 Hari + $500 dengan BOOST500",
 			"provider": "UpCloud",
 			"status": "active",
 			"tags": ["Cloud", "Hosting", "Free Trial", "Developer Tools"],

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -741,7 +741,7 @@
 		},
 		{
 			"id": "upcloud-free-trial",
-			"title": "UpCloud Free Trial hingga 30 Hari + $500 dengan BOOST500",
+			"title": "UpCloud Free Trial hingga 30 Hari + $500",
 			"provider": "UpCloud",
 			"status": "active",
 			"tags": ["Cloud", "Hosting", "Free Trial", "Developer Tools"],

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-02",
-	"total": 81,
+	"total": 82,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -738,6 +738,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-18",
 			"contributorSlug": "bang-joe"
+		},
+		{
+			"id": "upcloud-free-trial",
+			"title": "UpCloud Free Trial 7 Hari untuk Cloud Server",
+			"provider": "UpCloud",
+			"status": "active",
+			"tags": ["Cloud", "Hosting", "Free Trial", "Developer Tools"],
+			"featured": false,
+			"publishedAt": "2026-08-03",
+			"contributorSlug": "wauputr4"
 		},
 		{
 			"id": "v0-vercel-ai-credits-up-to-200",

--- a/src/lib/data/bansos/upcloud-free-trial/README.md
+++ b/src/lib/data/bansos/upcloud-free-trial/README.md
@@ -1,0 +1,42 @@
+# ✅ UpCloud Free Trial 7 Hari untuk Cloud Server
+
+**Provider:** UpCloud
+
+UpCloud memberi pengguna baru free trial 7 hari untuk menguji cloud server dan layanan managed dalam kuota tertentu.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Trial berlangsung 7 hari setelah aktivasi; promosi lain dapat memberi durasi berbeda dan eligibility dapat berubah.
+
+## Keuntungan
+
+- Trial 7 hari setelah diaktifkan
+- Cloud Server hingga 2 core dan 4 GB RAM
+- Block Storage hingga 60 GB untuk Archive, Standard, dan MaxIOPS
+- Managed Database 1 node: MySQL, PostgreSQL, Valkey, atau OpenSearch
+- Managed Kubernetes, Object Storage, Load Balancer, dan networking dalam kuota trial
+
+## Persyaratan
+
+- Buat akun UpCloud baru
+- Login dan aktifkan free trial dalam 365 hari setelah registrasi
+- Verifikasi identitas dengan kartu kredit dan informasi billing
+- Siapkan kartu untuk otorisasi sementara 0 atau 1 EUR/USD
+- Gunakan layanan sesuai kuota trial dan Terms of Service
+
+## Tips
+
+Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial. Hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.
+
+---
+
+[🔗 Klaim Bansos Ini](https://signup.upcloud.com/)
+
+
+🏷️ Tags: Cloud · Hosting · Free Trial · Developer Tools
+
+✏️ Dikontribusikan oleh `wauputr4`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/upcloud-free-trial/README.md
+++ b/src/lib/data/bansos/upcloud-free-trial/README.md
@@ -1,19 +1,19 @@
-# ✅ UpCloud Free Trial hingga 30 Hari + $500 dengan BOOST500
+# ✅ UpCloud Free Trial hingga 30 Hari + $500
 
 **Provider:** UpCloud
 
-UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsung kontributor, kode BOOST500 dapat membuka promo hingga 30 hari free trial dan benefit $500 setelah verifikasi akun serta setup pembayaran dengan kartu kredit.
+UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsung kontributor, promo tertentu dapat membuka hingga 30 hari free trial dan benefit $500 setelah verifikasi akun serta setup pembayaran dengan kartu kredit.
 
 > **Status:** Aktif
 
-⏰ **Info Waktu:** Trial standar berlangsung 7 hari setelah aktivasi; hasil uji langsung menunjukkan BOOST500 dapat memberi hingga 30 hari dan benefit $500. Promo, durasi, dan eligibility dapat berubah.
+⏰ **Info Waktu:** Trial standar berlangsung 7 hari setelah aktivasi; hasil uji langsung menunjukkan promo tertentu dapat memberi hingga 30 hari dan benefit $500. Promo, durasi, dan eligibility dapat berubah.
 
 🏷️ **Promo Code:** `BOOST500`
 
 ## Keuntungan
 
 - Trial 7 hari setelah diaktifkan
-- Kode BOOST500: hasil uji langsung kontributor menunjukkan hingga 30 hari free trial dan benefit $500
+- Promo tertentu: hasil uji langsung kontributor menunjukkan hingga 30 hari free trial dan benefit $500
 - Cloud Server hingga 2 core dan 4 GB RAM
 - Block Storage hingga 60 GB untuk Archive, Standard, dan MaxIOPS
 - Managed Database 1 node: MySQL, PostgreSQL, Valkey, atau OpenSearch
@@ -27,7 +27,7 @@ UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsun
 
 - Buat akun UpCloud baru
 - Login dan aktifkan free trial dalam 365 hari setelah registrasi
-- Masukkan kode promo BOOST500 saat pendaftaran jika masih diterima
+- Masukkan kode promo yang tersedia saat pendaftaran jika masih diterima
 - Verifikasi identitas dengan informasi billing
 - Siapkan dan setup pembayaran dengan kartu kredit untuk mengaktifkan promo
 - Siapkan kartu untuk otorisasi sementara 0 atau 1 EUR/USD
@@ -36,7 +36,7 @@ UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsun
 
 ## Tips
 
-Kode BOOST500 ditemukan dan berhasil diuji langsung oleh kontributor; ketersediaan dan eligibility dapat berubah serta belum tercantum di dokumentasi publik. Penawaran $10+ adalah pembayaran saldo prepaid, bukan benefit gratis. Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial; hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Jaminan pengembalian dana 30 hari hingga $500 berlaku untuk pembayaran pertama. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.
+Kode promo ini ditemukan dan berhasil diuji langsung oleh kontributor; ketersediaan dan eligibility dapat berubah serta belum tercantum di dokumentasi publik. Penawaran $10+ adalah pembayaran saldo prepaid, bukan benefit gratis. Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial; hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Jaminan pengembalian dana 30 hari hingga $500 berlaku untuk pembayaran pertama. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.
 
 ---
 

--- a/src/lib/data/bansos/upcloud-free-trial/README.md
+++ b/src/lib/data/bansos/upcloud-free-trial/README.md
@@ -1,32 +1,42 @@
-# ✅ UpCloud Free Trial 7 Hari untuk Cloud Server
+# ✅ UpCloud Free Trial hingga 30 Hari + $500 dengan BOOST500
 
 **Provider:** UpCloud
 
-UpCloud memberi pengguna baru free trial 7 hari untuk menguji cloud server dan layanan managed dalam kuota tertentu.
+UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsung kontributor, kode BOOST500 dapat membuka promo hingga 30 hari free trial dan benefit $500 setelah verifikasi akun serta setup pembayaran dengan kartu kredit.
 
 > **Status:** Aktif
 
-⏰ **Info Waktu:** Trial berlangsung 7 hari setelah aktivasi; promosi lain dapat memberi durasi berbeda dan eligibility dapat berubah.
+⏰ **Info Waktu:** Trial standar berlangsung 7 hari setelah aktivasi; hasil uji langsung menunjukkan BOOST500 dapat memberi hingga 30 hari dan benefit $500. Promo, durasi, dan eligibility dapat berubah.
+
+🏷️ **Promo Code:** `BOOST500`
 
 ## Keuntungan
 
 - Trial 7 hari setelah diaktifkan
+- Kode BOOST500: hasil uji langsung kontributor menunjukkan hingga 30 hari free trial dan benefit $500
 - Cloud Server hingga 2 core dan 4 GB RAM
 - Block Storage hingga 60 GB untuk Archive, Standard, dan MaxIOPS
 - Managed Database 1 node: MySQL, PostgreSQL, Valkey, atau OpenSearch
 - Managed Kubernetes, Object Storage, Load Balancer, dan networking dalam kuota trial
+- Tambahkan minimal $10 ke saldo untuk menghapus batas trial dan mempertahankan layanan trial
+- Akses penuh ke semua produk dan dukungan 24/7 setelah saldo ditambahkan
+- Model prepaid: tambahkan saldo lalu gunakan sesuai pemakaian
+- Jaminan pengembalian dana 30 hari untuk pembayaran pertama hingga $500
 
 ## Persyaratan
 
 - Buat akun UpCloud baru
 - Login dan aktifkan free trial dalam 365 hari setelah registrasi
-- Verifikasi identitas dengan kartu kredit dan informasi billing
+- Masukkan kode promo BOOST500 saat pendaftaran jika masih diterima
+- Verifikasi identitas dengan informasi billing
+- Siapkan dan setup pembayaran dengan kartu kredit untuk mengaktifkan promo
 - Siapkan kartu untuk otorisasi sementara 0 atau 1 EUR/USD
+- Tambahkan minimal $10 ke saldo jika ingin menghapus batas trial dan mempertahankan layanan
 - Gunakan layanan sesuai kuota trial dan Terms of Service
 
 ## Tips
 
-Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial. Hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.
+Kode BOOST500 ditemukan dan berhasil diuji langsung oleh kontributor; ketersediaan dan eligibility dapat berubah serta belum tercantum di dokumentasi publik. Penawaran $10+ adalah pembayaran saldo prepaid, bukan benefit gratis. Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial; hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Jaminan pengembalian dana 30 hari hingga $500 berlaku untuk pembayaran pertama. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.
 
 ---
 

--- a/src/lib/data/bansos/upcloud-free-trial/index.json
+++ b/src/lib/data/bansos/upcloud-free-trial/index.json
@@ -1,0 +1,32 @@
+{
+	"id": "upcloud-free-trial",
+	"title": "UpCloud Free Trial 7 Hari untuk Cloud Server",
+	"provider": "UpCloud",
+	"description": "UpCloud memberi pengguna baru free trial 7 hari untuk menguji cloud server dan layanan managed dalam kuota tertentu.",
+	"benefits": [
+		"Trial 7 hari setelah diaktifkan",
+		"Cloud Server hingga 2 core dan 4 GB RAM",
+		"Block Storage hingga 60 GB untuk Archive, Standard, dan MaxIOPS",
+		"Managed Database 1 node: MySQL, PostgreSQL, Valkey, atau OpenSearch",
+		"Managed Kubernetes, Object Storage, Load Balancer, dan networking dalam kuota trial"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Trial berlangsung 7 hari setelah aktivasi; promosi lain dapat memberi durasi berbeda dan eligibility dapat berubah."
+	},
+	"requirements": [
+		"Buat akun UpCloud baru",
+		"Login dan aktifkan free trial dalam 365 hari setelah registrasi",
+		"Verifikasi identitas dengan kartu kredit dan informasi billing",
+		"Siapkan kartu untuk otorisasi sementara 0 atau 1 EUR/USD",
+		"Gunakan layanan sesuai kuota trial dan Terms of Service"
+	],
+	"ctaLink": "https://signup.upcloud.com/",
+	"tags": ["Cloud", "Hosting", "Free Trial", "Developer Tools"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-03",
+	"tips": "Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial. Hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.",
+	"source": "https://upcloud.com/docs/getting-started/free-trial/",
+	"contributorSlug": "wauputr4"
+}

--- a/src/lib/data/bansos/upcloud-free-trial/index.json
+++ b/src/lib/data/bansos/upcloud-free-trial/index.json
@@ -1,24 +1,32 @@
 {
 	"id": "upcloud-free-trial",
-	"title": "UpCloud Free Trial 7 Hari untuk Cloud Server",
+	"title": "UpCloud Free Trial hingga 30 Hari + $500 dengan BOOST500",
 	"provider": "UpCloud",
-	"description": "UpCloud memberi pengguna baru free trial 7 hari untuk menguji cloud server dan layanan managed dalam kuota tertentu.",
+	"description": "UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsung kontributor, kode BOOST500 dapat membuka promo hingga 30 hari free trial dan benefit $500 setelah verifikasi akun serta setup pembayaran dengan kartu kredit.",
 	"benefits": [
 		"Trial 7 hari setelah diaktifkan",
+		"Kode BOOST500: hasil uji langsung kontributor menunjukkan hingga 30 hari free trial dan benefit $500",
 		"Cloud Server hingga 2 core dan 4 GB RAM",
 		"Block Storage hingga 60 GB untuk Archive, Standard, dan MaxIOPS",
 		"Managed Database 1 node: MySQL, PostgreSQL, Valkey, atau OpenSearch",
-		"Managed Kubernetes, Object Storage, Load Balancer, dan networking dalam kuota trial"
+		"Managed Kubernetes, Object Storage, Load Balancer, dan networking dalam kuota trial",
+		"Tambahkan minimal $10 ke saldo untuk menghapus batas trial dan mempertahankan layanan trial",
+		"Akses penuh ke semua produk dan dukungan 24/7 setelah saldo ditambahkan",
+		"Model prepaid: tambahkan saldo lalu gunakan sesuai pemakaian",
+		"Jaminan pengembalian dana 30 hari untuk pembayaran pertama hingga $500"
 	],
 	"validity": {
 		"type": "uncertain",
-		"description": "Trial berlangsung 7 hari setelah aktivasi; promosi lain dapat memberi durasi berbeda dan eligibility dapat berubah."
+		"description": "Trial standar berlangsung 7 hari setelah aktivasi; hasil uji langsung menunjukkan BOOST500 dapat memberi hingga 30 hari dan benefit $500. Promo, durasi, dan eligibility dapat berubah."
 	},
 	"requirements": [
 		"Buat akun UpCloud baru",
 		"Login dan aktifkan free trial dalam 365 hari setelah registrasi",
-		"Verifikasi identitas dengan kartu kredit dan informasi billing",
+		"Masukkan kode promo BOOST500 saat pendaftaran jika masih diterima",
+		"Verifikasi identitas dengan informasi billing",
+		"Siapkan dan setup pembayaran dengan kartu kredit untuk mengaktifkan promo",
 		"Siapkan kartu untuk otorisasi sementara 0 atau 1 EUR/USD",
+		"Tambahkan minimal $10 ke saldo jika ingin menghapus batas trial dan mempertahankan layanan",
 		"Gunakan layanan sesuai kuota trial dan Terms of Service"
 	],
 	"ctaLink": "https://signup.upcloud.com/",
@@ -26,7 +34,8 @@
 	"status": "active",
 	"featured": false,
 	"publishedAt": "2026-08-03",
-	"tips": "Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial. Hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.",
+	"tips": "Kode BOOST500 ditemukan dan berhasil diuji langsung oleh kontributor; ketersediaan dan eligibility dapat berubah serta belum tercantum di dokumentasi publik. Penawaran $10+ adalah pembayaran saldo prepaid, bukan benefit gratis. Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial; hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Jaminan pengembalian dana 30 hari hingga $500 berlaku untuk pembayaran pertama. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.",
 	"source": "https://upcloud.com/docs/getting-started/free-trial/",
-	"contributorSlug": "wauputr4"
+	"contributorSlug": "wauputr4",
+	"promoCode": "BOOST500"
 }

--- a/src/lib/data/bansos/upcloud-free-trial/index.json
+++ b/src/lib/data/bansos/upcloud-free-trial/index.json
@@ -1,11 +1,11 @@
 {
 	"id": "upcloud-free-trial",
-	"title": "UpCloud Free Trial hingga 30 Hari + $500 dengan BOOST500",
+	"title": "UpCloud Free Trial hingga 30 Hari + $500",
 	"provider": "UpCloud",
-	"description": "UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsung kontributor, kode BOOST500 dapat membuka promo hingga 30 hari free trial dan benefit $500 setelah verifikasi akun serta setup pembayaran dengan kartu kredit.",
+	"description": "UpCloud memberi pengguna baru free trial standar 7 hari. Berdasarkan uji langsung kontributor, promo tertentu dapat membuka hingga 30 hari free trial dan benefit $500 setelah verifikasi akun serta setup pembayaran dengan kartu kredit.",
 	"benefits": [
 		"Trial 7 hari setelah diaktifkan",
-		"Kode BOOST500: hasil uji langsung kontributor menunjukkan hingga 30 hari free trial dan benefit $500",
+		"Promo tertentu: hasil uji langsung kontributor menunjukkan hingga 30 hari free trial dan benefit $500",
 		"Cloud Server hingga 2 core dan 4 GB RAM",
 		"Block Storage hingga 60 GB untuk Archive, Standard, dan MaxIOPS",
 		"Managed Database 1 node: MySQL, PostgreSQL, Valkey, atau OpenSearch",
@@ -17,12 +17,12 @@
 	],
 	"validity": {
 		"type": "uncertain",
-		"description": "Trial standar berlangsung 7 hari setelah aktivasi; hasil uji langsung menunjukkan BOOST500 dapat memberi hingga 30 hari dan benefit $500. Promo, durasi, dan eligibility dapat berubah."
+		"description": "Trial standar berlangsung 7 hari setelah aktivasi; hasil uji langsung menunjukkan promo tertentu dapat memberi hingga 30 hari dan benefit $500. Promo, durasi, dan eligibility dapat berubah."
 	},
 	"requirements": [
 		"Buat akun UpCloud baru",
 		"Login dan aktifkan free trial dalam 365 hari setelah registrasi",
-		"Masukkan kode promo BOOST500 saat pendaftaran jika masih diterima",
+		"Masukkan kode promo yang tersedia saat pendaftaran jika masih diterima",
 		"Verifikasi identitas dengan informasi billing",
 		"Siapkan dan setup pembayaran dengan kartu kredit untuk mengaktifkan promo",
 		"Siapkan kartu untuk otorisasi sementara 0 atau 1 EUR/USD",
@@ -34,7 +34,7 @@
 	"status": "active",
 	"featured": false,
 	"publishedAt": "2026-08-03",
-	"tips": "Kode BOOST500 ditemukan dan berhasil diuji langsung oleh kontributor; ketersediaan dan eligibility dapat berubah serta belum tercantum di dokumentasi publik. Penawaran $10+ adalah pembayaran saldo prepaid, bukan benefit gratis. Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial; hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Jaminan pengembalian dana 30 hari hingga $500 berlaku untuk pembayaran pertama. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.",
+	"tips": "Kode promo ini ditemukan dan berhasil diuji langsung oleh kontributor; ketersediaan dan eligibility dapat berubah serta belum tercantum di dokumentasi publik. Penawaran $10+ adalah pembayaran saldo prepaid, bukan benefit gratis. Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud mulai menagih setelah trial; hentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar. Jaminan pengembalian dana 30 hari hingga $500 berlaku untuk pembayaran pertama. Trial tidak mencakup Windows, GPU, Private Cloud, atau Private Cloud GPU; port SMTP 25 diblokir. Terms mengarahkan layanan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.",
 	"source": "https://upcloud.com/docs/getting-started/free-trial/",
 	"contributorSlug": "wauputr4",
 	"promoCode": "BOOST500"


### PR DESCRIPTION
## Ringkasan

Menambah dan memperbarui listing **UpCloud Free Trial hingga 30 Hari + $500 dengan BOOST500**.

Listing membedakan trial standar UpCloud dari promo yang diuji langsung:

- Trial standar 7 hari setelah aktivasi.
- Kode promo `BOOST500` diuji langsung oleh kontributor dan menunjukkan hingga 30 hari free trial serta benefit $500.
- Aktivasi promo memerlukan verifikasi akun dan setup pembayaran dengan kartu kredit.
- Menambahkan minimal $10 ke saldo dapat menghapus batas trial dan mempertahankan layanan trial.
- Model prepaid, akses semua produk, dan dukungan 24/7 dicantumkan sebagai detail penawaran.
- Pembayaran pertama memiliki jaminan pengembalian dana 30 hari hingga $500.

## Sumber resmi

- Dokumentasi free trial: https://upcloud.com/docs/getting-started/free-trial/
- Halaman pendaftaran: https://signup.upcloud.com/
- Terms of Service: https://upcloud.com/terms-of-service/

## Catatan promo

- `BOOST500` adalah hasil uji langsung kontributor pada 2026-08-03; kode, durasi, benefit, dan eligibility dapat berubah serta belum tercantum di dokumentasi publik.
- Detail promo tidak diposisikan sebagai jaminan universal. Pengguna tetap perlu memeriksa hasil akhir di halaman pendaftaran dan syarat UpCloud.
- Dokumentasi menyebut kartu tidak ditagih sebelum, selama, atau sesudah trial, tetapi Terms memberi hak UpCloud untuk mulai menagih setelah trial. Pengguna perlu menghentikan subscription sebelum trial berakhir jika tidak ingin lanjut berbayar.
- Trial tidak mencakup Windows Server, GPU Server, Private Cloud, atau Private Cloud GPU.
- Terms menyatakan layanan ditujukan untuk kebutuhan bisnis dan profesional, bukan penggunaan personal.

## Atribusi

Kontributor: `wauputr4` — https://github.com/wauputr4

## Validasi

- `npm run validate:data` — ✅ 82 folder dan referensi kontributor valid
- `npm run check` — ✅ svelte-check 0 error, 0 warning
- `npm run lint` — ✅ exit 0; 2 warning lama pada route yang tidak terkait
- `git diff --check` — ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UpCloud’s free trial to the available benefits directory.
  * Included standard trial details, the manually tested BOOST500 promo, services, quotas, eligibility, verification, billing terms, exclusions, and usage guidance.
  * Added signup links, categorization tags, validity information, and contributor attribution.
  * Updated the directory total to 82 available benefits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->