### PR TITLE
feat: add JetBrains Student Pack listing

### DIFF
--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -204,6 +204,11 @@
 		"date": "2026-07-11T08:20:24Z",
 		"url": "https://github.com/wauputr4/bansos/commit/90a36ce7dc5df0d8ba8e36e11fbe8f9699cb70bf"
 	},
+	"jetbrains-student-pack": {
+		"hash": "43e5f17c0e8669b7a69bc4d62dfed3d0083aecaa",
+		"date": "2026-08-05T23:46:59+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/43e5f17c0e8669b7a69bc4d62dfed3d0083aecaa"
+	},
 	"kie-ai-api-discount-credit": {
 		"hash": "3750e3969354d6594529e80d4e2f5db9ea98dd63",
 		"date": "2026-06-30T08:00:14Z",

--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -205,9 +205,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/90a36ce7dc5df0d8ba8e36e11fbe8f9699cb70bf"
 	},
 	"jetbrains-student-pack": {
-		"hash": "43e5f17c0e8669b7a69bc4d62dfed3d0083aecaa",
-		"date": "2026-08-05T23:46:59+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/43e5f17c0e8669b7a69bc4d62dfed3d0083aecaa"
+		"hash": "bddbcd50f724c5645148385b88b135e52225c170",
+		"date": "2026-08-06T00:02:59+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/bddbcd50f724c5645148385b88b135e52225c170"
 	},
 	"kie-ai-api-discount-credit": {
 		"hash": "3750e3969354d6594529e80d4e2f5db9ea98dd63",

--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -205,9 +205,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/90a36ce7dc5df0d8ba8e36e11fbe8f9699cb70bf"
 	},
 	"jetbrains-student-pack": {
-		"hash": "97263a05087bcd5e72d1a65756613c24851a3be7",
-		"date": "2026-08-06T00:06:31+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/97263a05087bcd5e72d1a65756613c24851a3be7"
+		"hash": "982c132c338f0d410293560ebebd82c13e73f640",
+		"date": "2026-08-06T00:19:53+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/982c132c338f0d410293560ebebd82c13e73f640"
 	},
 	"kie-ai-api-discount-credit": {
 		"hash": "3750e3969354d6594529e80d4e2f5db9ea98dd63",

--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -205,9 +205,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/90a36ce7dc5df0d8ba8e36e11fbe8f9699cb70bf"
 	},
 	"jetbrains-student-pack": {
-		"hash": "bddbcd50f724c5645148385b88b135e52225c170",
-		"date": "2026-08-06T00:02:59+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/bddbcd50f724c5645148385b88b135e52225c170"
+		"hash": "97263a05087bcd5e72d1a65756613c24851a3be7",
+		"date": "2026-08-06T00:06:31+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/97263a05087bcd5e72d1a65756613c24851a3be7"
 	},
 	"kie-ai-api-discount-credit": {
 		"hash": "3750e3969354d6594529e80d4e2f5db9ea98dd63",

--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -115,9 +115,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/1157999e5dd65910aa60af5c6510bb7f024a4c12"
 	},
 	"free-5-credit-for-new-opencode-go-users": {
-		"hash": "dbe76c29652e370eb9193904fe95b13f65442fb2",
-		"date": "2026-07-26T00:08:37+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/dbe76c29652e370eb9193904fe95b13f65442fb2"
+		"hash": "bc739a1e94f5bb7fc5d62d5b25b1746d14901208",
+		"date": "2026-07-30T14:41:35+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/bc739a1e94f5bb7fc5d62d5b25b1746d14901208"
 	},
 	"freebuff-ai-builder": {
 		"hash": "82ac7b27164b75a5e61be298d14856f13e73296b",
@@ -158,6 +158,11 @@
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+	},
+	"gorouter-free-75-ai-credit": {
+		"hash": "08b227e385a3c8b146979c2498c6d67e0128e0ef",
+		"date": "2026-07-29T21:18:41+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/08b227e385a3c8b146979c2498c6d67e0128e0ef"
 	},
 	"gumloop-free-credits": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
@@ -275,9 +280,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
 	"opencode-go-free-5-credit": {
-		"hash": "72652d38096856179805412b6f5fe98660971f27",
-		"date": "2026-06-24T10:46:54Z",
-		"url": "https://github.com/wauputr4/bansos/commit/72652d38096856179805412b6f5fe98660971f27"
+		"hash": "bc739a1e94f5bb7fc5d62d5b25b1746d14901208",
+		"date": "2026-07-30T14:41:35+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/bc739a1e94f5bb7fc5d62d5b25b1746d14901208"
 	},
 	"openmodel-deepseek-v4-flash-free": {
 		"hash": "31af1e4a08784c119231e75d2d9b74041a5f07ae",
@@ -290,9 +295,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/61d86bf2a5b48c24e80d47599dfe9154e733a872"
 	},
 	"promo-domain-sitequ": {
-		"hash": "d212d25b22a6b424fe27bd7415e5b3b9c33db364",
-		"date": "2026-07-24T00:30:26+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/d212d25b22a6b424fe27bd7415e5b3b9c33db364"
+		"hash": "5c3849b1021c2b54ea66e88142ee970c4ea24793",
+		"date": "2026-08-02T18:56:52+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/5c3849b1021c2b54ea66e88142ee970c4ea24793"
 	},
 	"qoder-qwen-max-free": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
@@ -303,6 +308,11 @@
 		"hash": "3750e3969354d6594529e80d4e2f5db9ea98dd63",
 		"date": "2026-06-30T08:00:14Z",
 		"url": "https://github.com/wauputr4/bansos/commit/3750e3969354d6594529e80d4e2f5db9ea98dd63"
+	},
+	"seekai-free-200-ai-credit": {
+		"hash": "16d9e857eb7c11c17ec7be49f94e840ea6fc3f0f",
+		"date": "2026-08-02T19:22:53+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/16d9e857eb7c11c17ec7be49f94e840ea6fc3f0f"
 	},
 	"servernusa-free-xiaomi-mimo": {
 		"hash": "09cdc6cf06088fd26c1c14fa57fd401c10f7196e",
@@ -349,6 +359,11 @@
 		"date": "2026-06-30T08:00:14Z",
 		"url": "https://github.com/wauputr4/bansos/commit/3750e3969354d6594529e80d4e2f5db9ea98dd63"
 	},
+	"upcloud-free-trial": {
+		"hash": "09344f8f14ad5e37319c492b5a4bbb9c0d8e448c",
+		"date": "2026-08-03T19:54:13+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/09344f8f14ad5e37319c492b5a4bbb9c0d8e448c"
+	},
 	"v0-vercel-ai-credits-up-to-200": {
 		"hash": "4f31dd415d9b2af10ec51dfb03c95fde77883ce8",
 		"date": "2026-06-27T05:37:05Z",
@@ -358,6 +373,11 @@
 		"hash": "6f513f3507ad72b3c69fa07b48c671dd2908c256",
 		"date": "2026-07-23T16:50:42+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/6f513f3507ad72b3c69fa07b48c671dd2908c256"
+	},
+	"vyce-ai-free-40-credit": {
+		"hash": "1d98737faaebcf662fb15762b3c4c348aa10369c",
+		"date": "2026-08-03T18:33:10+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/1d98737faaebcf662fb15762b3c4c348aa10369c"
 	},
 	"xai-grok-api-credits": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",

--- a/src/lib/data/bansos/contributors/wenn-id/README.md
+++ b/src/lib/data/bansos/contributors/wenn-id/README.md
@@ -1,0 +1,3 @@
+# Alwan Juliawan
+
+Kontributor komunitas [bansos.dev](https://bansos.dev).

--- a/src/lib/data/bansos/contributors/wenn-id/manifest.json
+++ b/src/lib/data/bansos/contributors/wenn-id/manifest.json
@@ -1,0 +1,13 @@
+{
+	"login": "wenn-id",
+	"displayName": "Alwan Juliawan",
+	"bio": "",
+	"title": "",
+	"skills": [],
+	"links": {
+		"github": "https://github.com/wenn-id"
+	},
+	"contributedBansos": ["jetbrains-student-pack"],
+	"hidden": false,
+	"joinedAt": "2026-08-05"
+}

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-02",
-	"total": 82,
+	"total": 83,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -419,6 +419,16 @@
 			"featured": true,
 			"publishedAt": "2026-07-11",
 			"contributorSlug": "wauputr4"
+		},
+		{
+			"id": "jetbrains-student-pack",
+			"title": "JetBrains Student Pack — Semua IDE Gratis untuk Pelajar",
+			"provider": "JetBrains",
+			"status": "active",
+			"tags": ["Developer Tools", "IDEs", "Free Tier", "Student", "Education"],
+			"featured": false,
+			"publishedAt": "2026-08-05",
+			"contributorSlug": "wenn-id"
 		},
 		{
 			"id": "kie-ai-api-discount-credit",

--- a/src/lib/data/bansos/jetbrains-student-pack/README.md
+++ b/src/lib/data/bansos/jetbrains-student-pack/README.md
@@ -1,0 +1,35 @@
+# ✅ JetBrains Student Pack — Semua IDE Gratis untuk Pelajar
+
+**Provider:** JetBrains
+
+Akses gratis semua produk JetBrains (IntelliJ IDEA, PyCharm, WebStorm, CLion, DataGrip, dan lainnya) untuk pelajar, mahasiswa, dan peserta bootcamp/course. Termasuk plugin, sertifikat ujian, dan akses ke JetBrains Academy courses.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Lisensi berlaku 1 tahun dan dapat diperpanjang selama masih berstatus pelajar
+
+## Keuntungan
+
+- Semua IDE JetBrains (All Products Pack) gratis
+- Akses plugin premium & sertifikat ujian resmi
+- JetBrains Academy — belajar coding interaktif
+- Lisensi gratis 1 tahun, bisa diperpanjang selama masih jadi pelajar
+
+## Persyaratan
+
+- Berstatus pelajar/mahasiswa di sekolah, universitas, atau bootcamp/course
+- Verifikasi identitas via email institusi atau dokumen resmi
+- Perpanjang lisensi tiap tahun selama masih memenuhi syarat
+
+---
+
+[🔗 Klaim Bansos Ini](https://www.jetbrains.com/shop/eform/v2/students)
+
+
+🏷️ Tags: Developer Tools · IDEs · Free Tier · Student · Education
+
+✏️ Dikontribusikan oleh `wenn-id`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/jetbrains-student-pack/README.md
+++ b/src/lib/data/bansos/jetbrains-student-pack/README.md
@@ -2,7 +2,7 @@
 
 **Provider:** JetBrains
 
-Akses gratis semua produk JetBrains (IntelliJ IDEA, PyCharm, WebStorm, CLion, DataGrip, dan lainnya) untuk pelajar, mahasiswa, dan peserta bootcamp/course. Termasuk plugin, sertifikat ujian, dan akses ke JetBrains Academy courses.
+Akses gratis semua produk JetBrains untuk mahasiswa full-time: 10 IDE (IntelliJ IDEA, PyCharm, WebStorm, CLion, DataGrip, GoLand, PhpStorm, Rider, RubyMine, RustRover), ditambah trial JetBrains AI Pro dan akses kursus coding JetBrains Academy.
 
 > **Status:** Aktif
 
@@ -10,15 +10,15 @@ Akses gratis semua produk JetBrains (IntelliJ IDEA, PyCharm, WebStorm, CLion, Da
 
 ## Keuntungan
 
-- Semua IDE JetBrains (All Products Pack) gratis
-- Akses plugin premium & sertifikat ujian resmi
-- JetBrains Academy — belajar coding interaktif
+- 10 IDE JetBrains (All Products Pack) gratis untuk pelajar
+- Trial JetBrains AI Pro: unlimited code completion + AI chat & agents (Codex, Claude Agent, Junie)
+- JetBrains Academy — kursus coding hands-on di dalam IDE
 - Lisensi gratis 1 tahun, bisa diperpanjang selama masih jadi pelajar
 
 ## Persyaratan
 
-- Berstatus pelajar/mahasiswa di sekolah, universitas, atau bootcamp/course
-- Verifikasi identitas via email institusi atau dokumen resmi
+- Full-time student dalam program yang berlangsung minimal 1 tahun (universitas atau sekolah)
+- Verifikasi identitas via email universitas, kartu ISIC/ITIC, atau GitHub Student Developer Pack
 - Perpanjang lisensi tiap tahun selama masih memenuhi syarat
 
 ---

--- a/src/lib/data/bansos/jetbrains-student-pack/index.json
+++ b/src/lib/data/bansos/jetbrains-student-pack/index.json
@@ -1,0 +1,28 @@
+{
+	"id": "jetbrains-student-pack",
+	"title": "JetBrains Student Pack — Semua IDE Gratis untuk Pelajar",
+	"provider": "JetBrains",
+	"description": "Akses gratis semua produk JetBrains (IntelliJ IDEA, PyCharm, WebStorm, CLion, DataGrip, dan lainnya) untuk pelajar, mahasiswa, dan peserta bootcamp/course. Termasuk plugin, sertifikat ujian, dan akses ke JetBrains Academy courses.",
+	"benefits": [
+		"Semua IDE JetBrains (All Products Pack) gratis",
+		"Akses plugin premium & sertifikat ujian resmi",
+		"JetBrains Academy — belajar coding interaktif",
+		"Lisensi gratis 1 tahun, bisa diperpanjang selama masih jadi pelajar"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Lisensi berlaku 1 tahun dan dapat diperpanjang selama masih berstatus pelajar"
+	},
+	"requirements": [
+		"Berstatus pelajar/mahasiswa di sekolah, universitas, atau bootcamp/course",
+		"Verifikasi identitas via email institusi atau dokumen resmi",
+		"Perpanjang lisensi tiap tahun selama masih memenuhi syarat"
+	],
+	"ctaLink": "https://www.jetbrains.com/shop/eform/v2/students",
+	"tags": ["Developer Tools", "IDEs", "Free Tier", "Student", "Education"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-05",
+	"source": "https://www.jetbrains.com/academy/student-pack/",
+	"contributorSlug": "wenn-id"
+}

--- a/src/lib/data/bansos/jetbrains-student-pack/index.json
+++ b/src/lib/data/bansos/jetbrains-student-pack/index.json
@@ -2,11 +2,11 @@
 	"id": "jetbrains-student-pack",
 	"title": "JetBrains Student Pack — Semua IDE Gratis untuk Pelajar",
 	"provider": "JetBrains",
-	"description": "Akses gratis semua produk JetBrains (IntelliJ IDEA, PyCharm, WebStorm, CLion, DataGrip, dan lainnya) untuk pelajar, mahasiswa, dan peserta bootcamp/course. Termasuk plugin, sertifikat ujian, dan akses ke JetBrains Academy courses.",
+	"description": "Akses gratis semua produk JetBrains untuk mahasiswa full-time: 10 IDE (IntelliJ IDEA, PyCharm, WebStorm, CLion, DataGrip, GoLand, PhpStorm, Rider, RubyMine, RustRover), ditambah trial JetBrains AI Pro dan akses kursus coding JetBrains Academy.",
 	"benefits": [
-		"Semua IDE JetBrains (All Products Pack) gratis",
-		"Akses plugin premium & sertifikat ujian resmi",
-		"JetBrains Academy — belajar coding interaktif",
+		"10 IDE JetBrains (All Products Pack) gratis untuk pelajar",
+		"Trial JetBrains AI Pro: unlimited code completion + AI chat & agents (Codex, Claude Agent, Junie)",
+		"JetBrains Academy — kursus coding hands-on di dalam IDE",
 		"Lisensi gratis 1 tahun, bisa diperpanjang selama masih jadi pelajar"
 	],
 	"validity": {
@@ -14,8 +14,8 @@
 		"description": "Lisensi berlaku 1 tahun dan dapat diperpanjang selama masih berstatus pelajar"
 	},
 	"requirements": [
-		"Berstatus pelajar/mahasiswa di sekolah, universitas, atau bootcamp/course",
-		"Verifikasi identitas via email institusi atau dokumen resmi",
+		"Full-time student dalam program yang berlangsung minimal 1 tahun (universitas atau sekolah)",
+		"Verifikasi identitas via email universitas, kartu ISIC/ITIC, atau GitHub Student Developer Pack",
 		"Perpanjang lisensi tiap tahun selama masih memenuhi syarat"
 	],
 	"ctaLink": "https://www.jetbrains.com/shop/eform/v2/students",


### PR DESCRIPTION
## Ringkas Perubahan
Menambahkan listing **JetBrains Student Pack** ke katalog bansos.dev dan mendaftarkan `wenn-id` sebagai kontributor.

### Detail
- **Provider:** JetBrains
- **Akses:** 10 IDE JetBrains — IntelliJ IDEA, PyCharm, WebStorm, CLion, DataGrip, GoLand, PhpStorm, Rider, RubyMine, RustRover
- **Bonus:** trial JetBrains AI Pro + JetBrains Academy courses
- **Syarat:** full-time student dalam program minimal 1 tahun
- **Verifikasi:** email universitas / ISIC-ITIC / GitHub Student Developer Pack
- **Sumber resmi:** https://www.jetbrains.com/academy/student-pack/

### Verifikasi lokal
- [x] `npm run validate:data` — Validated 83 bansos folders and contributor references
- [x] `npm run check` — `svelte-check found 0 errors and 0 warnings`
- [x] `npm run lint` — Prettier dan ESLint pass
- [x] `git diff --check` — pass
- [x] Source dan CTA resmi diverifikasi HTTP 200
- [!] `npm run build` mencapai prerender lalu gagal pada pre-existing `/rafly/` 404 dari generated commit-contributor data. `origin/main` gagal dengan error identik; PR ini tidak mengubah generator atau data `rafly`.

Data dibuat via `npm run add:bansos`, lalu README disinkronkan dengan source JSON setelah review CodeRabbit.