### PR TITLE
feat: add Qoder Qwen3.8-Max promo

### DIFF
--- a/src/lib/data/bansos/contributors/renyx/README.md
+++ b/src/lib/data/bansos/contributors/renyx/README.md
@@ -1,0 +1,3 @@
+# Renyx
+
+Kontributor komunitas [bansos.dev](https://bansos.dev).

--- a/src/lib/data/bansos/contributors/renyx/manifest.json
+++ b/src/lib/data/bansos/contributors/renyx/manifest.json
@@ -1,0 +1,11 @@
+{
+	"login": "renyx",
+	"displayName": "Renyx",
+	"bio": "",
+	"title": "",
+	"skills": [],
+	"links": {},
+	"contributedBansos": ["qoder-qwen-38-max-free"],
+	"hidden": false,
+	"joinedAt": "2026-08-08"
+}

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
-	"generatedAt": "2026-08-02",
-	"total": 84,
+	"generatedAt": "2026-08-08",
+	"total": 85,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -640,10 +640,20 @@
 			"contributorSlug": "sitequ-digital-indonesia"
 		},
 		{
+			"id": "qoder-qwen-38-max-free",
+			"title": "Qoder Qwen3.8-Max — 800–2.000 Panggilan Gratis",
+			"provider": "Qoder",
+			"status": "active",
+			"tags": ["AI", "AI Credits"],
+			"featured": true,
+			"publishedAt": "2026-08-08",
+			"contributorSlug": "renyx"
+		},
+		{
 			"id": "qoder-qwen-max-free",
 			"title": "200 Panggilan Model Qwen3.7-Max Gratis per Hari di Qoder",
 			"provider": "Qoder",
-			"status": "active",
+			"status": "expired",
 			"tags": ["AI Credits"],
 			"featured": false,
 			"publishedAt": "2026-06-15",

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -665,7 +665,7 @@
 			"provider": "Qoder",
 			"status": "active",
 			"tags": ["AI", "AI Credits"],
-			"featured": true,
+			"featured": false,
 			"publishedAt": "2026-08-08",
 			"contributorSlug": "renyx"
 		},

--- a/src/lib/data/bansos/qoder-qwen-38-max-free/README.md
+++ b/src/lib/data/bansos/qoder-qwen-38-max-free/README.md
@@ -1,0 +1,36 @@
+# ✅ Qoder Qwen3.8-Max — 800–2.000 Panggilan Gratis
+
+**Provider:** Qoder
+
+Promo ulang tahun pertama Qoder dan peluncuran Qwen3.8-Max: pengguna baru Pro Trial dan pengguna berbayar yang memenuhi syarat dapat mengklaim 800 panggilan gratis, sementara pembelian paket selama event memberi bonus 2.000 panggilan tambahan.
+
+> **Status:** Aktif
+
+⏰ **Berlaku sampai:** 2026-09-03
+
+## Keuntungan
+
+- 800 panggilan Qwen3.8-Max gratis untuk pengguna baru yang terdaftar sebagai Pro Trial
+- 800 panggilan untuk pengguna berbayar yang terdaftar sebelum 3 Agustus dan memiliki pesanan berbayar pada 3 Juli–2 Agustus
+- Bonus 2.000 panggilan untuk pembelian Pro, Pro+, Ultra, atau Personal Resource Pack selama event; dapat ditumpuk dengan 800 panggilan
+- Klaim di panel Usage dan gunakan lintas Qoder Desktop, JetBrains Plugin, CLI, dan QoderWake
+
+## Persyaratan
+
+- Update Qoder ke versi terbaru lalu login
+- Pengguna baru harus terdaftar sebagai Pro Trial; pengguna berbayar lama harus memenuhi periode pendaftaran dan pesanan yang ditentukan Qoder
+- Klaim 800 panggilan di panel Usage sebelum 3 September 2026
+- Untuk bonus 2.000 panggilan, lakukan pembelian Pro, Pro+, Ultra, atau Personal Resource Pack selama event lalu klaim di panel Usage
+- Hanya pengguna paket individual yang eligible; paket Teams tidak termasuk
+
+---
+
+[🔗 Klaim Bansos Ini](https://qoder.com/en)
+
+🏷️ Tags: AI · AI Credits
+
+✏️ Dikontribusikan oleh `renyx`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/qoder-qwen-38-max-free/index.json
+++ b/src/lib/data/bansos/qoder-qwen-38-max-free/index.json
@@ -1,0 +1,31 @@
+{
+	"id": "qoder-qwen-38-max-free",
+	"title": "Qoder Qwen3.8-Max — 800–2.000 Panggilan Gratis",
+	"provider": "Qoder",
+	"description": "Promo ulang tahun pertama Qoder dan peluncuran Qwen3.8-Max: pengguna baru Pro Trial dan pengguna berbayar yang memenuhi syarat dapat mengklaim 800 panggilan gratis, sementara pembelian paket selama event memberi bonus 2.000 panggilan tambahan.",
+	"benefits": [
+		"800 panggilan Qwen3.8-Max gratis untuk pengguna baru yang terdaftar sebagai Pro Trial",
+		"800 panggilan untuk pengguna berbayar yang terdaftar sebelum 3 Agustus dan memiliki pesanan berbayar pada 3 Juli–2 Agustus",
+		"Bonus 2.000 panggilan untuk pembelian Pro, Pro+, Ultra, atau Personal Resource Pack selama event; dapat ditumpuk dengan 800 panggilan",
+		"Klaim di panel Usage dan gunakan lintas Qoder Desktop, JetBrains Plugin, CLI, dan QoderWake"
+	],
+	"requirements": [
+		"Update Qoder ke versi terbaru lalu login",
+		"Pengguna baru harus terdaftar sebagai Pro Trial; pengguna berbayar lama harus memenuhi periode pendaftaran dan pesanan yang ditentukan Qoder",
+		"Klaim 800 panggilan di panel Usage sebelum 3 September 2026",
+		"Untuk bonus 2.000 panggilan, lakukan pembelian Pro, Pro+, Ultra, atau Personal Resource Pack selama event lalu klaim di panel Usage",
+		"Hanya pengguna paket individual yang eligible; paket Teams tidak termasuk"
+	],
+	"validity": {
+		"type": "fixed",
+		"date": "2026-09-03",
+		"description": "Klaim berakhir 3 September 2026, 23:59 (UTC+8); panggilan yang belum digunakan hangus 30 September 2026, 23:59 (UTC+8)"
+	},
+	"ctaLink": "https://qoder.com/en",
+	"tags": ["AI", "AI Credits"],
+	"status": "active",
+	"featured": true,
+	"publishedAt": "2026-08-08",
+	"source": "https://docs.qoder.com/events/qwen-max",
+	"contributorSlug": "renyx"
+}

--- a/src/lib/data/bansos/qoder-qwen-38-max-free/index.json
+++ b/src/lib/data/bansos/qoder-qwen-38-max-free/index.json
@@ -24,7 +24,7 @@
 	"ctaLink": "https://qoder.com/en",
 	"tags": ["AI", "AI Credits"],
 	"status": "active",
-	"featured": true,
+	"featured": false,
 	"publishedAt": "2026-08-08",
 	"source": "https://docs.qoder.com/events/qwen-max",
 	"contributorSlug": "renyx"

--- a/src/lib/data/bansos/qoder-qwen-max-free/README.md
+++ b/src/lib/data/bansos/qoder-qwen-max-free/README.md
@@ -1,12 +1,12 @@
-# ✅ 200 Panggilan Model Qwen3.7-Max Gratis per Hari di Qoder
+# ❌ 200 Panggilan Model Qwen3.7-Max Gratis per Hari di Qoder
 
 **Provider:** Qoder
 
 Qoder memberikan promo waktu terbatas berupa 200 pemanggilan model Qwen3.7-Max gratis per hari untuk semua pengguna. Model ini dioptimalkan untuk skenario AI Agent dan pemahaman kode.
 
-> **Status:** Aktif
+> **Status:** Kadaluwarsa
 
-⏰ **Info Waktu:** tanggal akhir program belum ditentukan dan akan diumumkan lebih lanjut
+⏰ **Berlaku sampai:** 2026-06-22
 
 ## Keuntungan
 

--- a/src/lib/data/bansos/qoder-qwen-max-free/index.json
+++ b/src/lib/data/bansos/qoder-qwen-max-free/index.json
@@ -15,12 +15,13 @@
 		"Klaim hanya berlaku bagi akun pertama yang berhasil login pada satu perangkat/komputer selama kampanye berjalan"
 	],
 	"validity": {
-		"type": "uncertain",
-		"description": "tanggal akhir program belum ditentukan dan akan diumumkan lebih lanjut"
+		"type": "fixed",
+		"date": "2026-06-22",
+		"description": "Kampanye berakhir 22 Juni 2026, 23:59:59 waktu Singapura"
 	},
 	"ctaLink": "https://qoder.com/",
 	"tags": ["AI Credits"],
-	"status": "active",
+	"status": "expired",
 	"featured": false,
 	"publishedAt": "2026-06-15",
 	"source": "https://docs.qoder.com/events/qwen-max-daily-free",


### PR DESCRIPTION
## Summary

- Add the Qoder Qwen3.8-Max promotion with 800 free calls and the 2,000-call purchase bonus.
- Record the official eligibility rules, claim deadline, and expiration date from the [Qoder event page](https://docs.qoder.com/events/qwen-max).
- Mark the previous Qwen3.7 daily-call campaign expired and add Renyx contributor attribution.

## Validation

- `npm run validate:data`
- `npm run check`
- `npm run lint`
- Verified the new listing in the local preview at `/list/qoder-qwen-38-max-free/`.
