### PR TITLE
feat: add InferX DeepSeek V4 Flash listing

### DIFF
--- a/src/lib/data/bansos/contributors/renyx/README.md
+++ b/src/lib/data/bansos/contributors/renyx/README.md
@@ -1,0 +1,3 @@
+# Renyx
+
+Kontributor komunitas bansos.dev.

--- a/src/lib/data/bansos/contributors/renyx/manifest.json
+++ b/src/lib/data/bansos/contributors/renyx/manifest.json
@@ -1,0 +1,11 @@
+{
+	"login": "renyx",
+	"displayName": "Renyx",
+	"bio": "",
+	"title": "",
+	"skills": [],
+	"links": {},
+	"contributedBansos": ["inferx-deepseek-v4-flash"],
+	"hidden": false,
+	"joinedAt": "2026-08-08"
+}

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
-	"generatedAt": "2026-08-02",
-	"total": 84,
+	"generatedAt": "2026-08-08",
+	"total": 85,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -389,6 +389,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-12",
 			"contributorSlug": "wauputr4"
+		},
+		{
+			"id": "inferx-deepseek-v4-flash",
+			"title": "DeepSeek V4 Flash Gratis di InferX",
+			"provider": "InferX",
+			"status": "active",
+			"tags": ["AI", "API", "Free Tier"],
+			"featured": true,
+			"publishedAt": "2026-08-08",
+			"contributorSlug": "renyx"
 		},
 		{
 			"id": "jagoanhosting-free-domain-webid",

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-16",
-	"total": 90,
+	"total": 89,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -406,7 +406,7 @@
 			"provider": "InferX",
 			"status": "active",
 			"tags": ["AI", "API", "Free Tier"],
-			"featured": true,
+			"featured": false,
 			"publishedAt": "2026-08-08",
 			"contributorSlug": "renyx"
 		},

--- a/src/lib/data/bansos/inferx-deepseek-v4-flash/README.md
+++ b/src/lib/data/bansos/inferx-deepseek-v4-flash/README.md
@@ -1,0 +1,34 @@
+# ✅ DeepSeek V4 Flash Gratis di InferX
+
+**Provider:** InferX
+
+InferX saat ini menyediakan akses gratis ke model DeepSeek V4 Flash Preview melalui endpoint yang kompatibel dengan OpenAI API.
+
+> **Status:** Aktif
+
+⏰ **Masa berlaku:** belum ditentukan. Email pengusul menyebut 12 Agustus 2026, tetapi tanggal tersebut belum dapat diverifikasi dari sumber resmi.
+
+## Keuntungan
+
+- Akses gratis ke model DeepSeek V4 Flash Preview
+- Endpoint kompatibel dengan OpenAI API
+- Dapat digunakan dari aplikasi yang mendukung OpenAI-compatible API
+
+## Syarat dan Cara Klaim
+
+- Buka katalog endpoint InferX
+- Daftar atau login ke akun InferX
+- Pilih endpoint DeepSeek V4 Flash
+- Login untuk mendapatkan URL endpoint khusus tenant dan API key
+
+## Cara Klaim
+
+[🔗 Buka InferX Endpoints](https://model.inferx.net/catalog/endpoints)
+
+## Tags
+
+AI · API · Free Tier
+
+✏️ Dikontribusikan oleh `renyx`
+
+_[bansos.dev](https://bansos.dev) — Open Source Catalog_

--- a/src/lib/data/bansos/inferx-deepseek-v4-flash/index.json
+++ b/src/lib/data/bansos/inferx-deepseek-v4-flash/index.json
@@ -1,0 +1,29 @@
+{
+	"id": "inferx-deepseek-v4-flash",
+	"title": "DeepSeek V4 Flash Gratis di InferX",
+	"provider": "InferX",
+	"description": "InferX saat ini menyediakan akses gratis ke model DeepSeek V4 Flash Preview melalui endpoint yang kompatibel dengan OpenAI API.",
+	"benefits": [
+		"Akses gratis ke model DeepSeek V4 Flash Preview",
+		"Endpoint kompatibel dengan OpenAI API",
+		"Dapat digunakan dari aplikasi yang mendukung OpenAI-compatible API"
+	],
+	"requirements": [
+		"Buka katalog endpoint InferX",
+		"Daftar atau login ke akun InferX",
+		"Pilih endpoint DeepSeek V4 Flash",
+		"Login untuk mendapatkan URL endpoint khusus tenant dan API key"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Situs resmi menampilkan akses gratis, tetapi periode berakhir belum dapat diverifikasi; email pengusul menyebut 12 Agustus 2026"
+	},
+	"ctaLink": "https://model.inferx.net/catalog/endpoints",
+	"tags": ["AI", "API", "Free Tier"],
+	"status": "active",
+	"featured": true,
+	"publishedAt": "2026-08-08",
+	"source": "https://inferx.net/",
+	"providerWebsiteUrl": "https://inferx.net/",
+	"contributorSlug": "renyx"
+}

--- a/src/lib/data/bansos/inferx-deepseek-v4-flash/index.json
+++ b/src/lib/data/bansos/inferx-deepseek-v4-flash/index.json
@@ -21,7 +21,7 @@
 	"ctaLink": "https://model.inferx.net/catalog/endpoints",
 	"tags": ["AI", "API", "Free Tier"],
 	"status": "active",
-	"featured": true,
+	"featured": false,
 	"publishedAt": "2026-08-08",
 	"source": "https://inferx.net/",
 	"providerWebsiteUrl": "https://inferx.net/",


### PR DESCRIPTION
## Summary

- Add the InferX DeepSeek V4 Flash free-access listing.
- Keep the copy limited to claims supported by InferX's official homepage and endpoint catalog.

## Review notes

- The validity is marked uncertain because the email mentions 12 August 2026, but the official pages do not expose a consistent end date.
- Unverified claims about 9Router, OmniRouter, and Agent were omitted.

## Validation

- `npm run validate:data`
- Prettier check on all changed JSON and Markdown files
