### PR TITLE
feat: add xKiro Pro referral listing

### DIFF
--- a/src/lib/data/bansos/contributors/renyx/README.md
+++ b/src/lib/data/bansos/contributors/renyx/README.md
@@ -1,0 +1,3 @@
+# Renyx
+
+Kontributor komunitas bansos.dev.

--- a/src/lib/data/bansos/contributors/renyx/manifest.json
+++ b/src/lib/data/bansos/contributors/renyx/manifest.json
@@ -1,0 +1,11 @@
+{
+	"login": "renyx",
+	"displayName": "Renyx",
+	"bio": "",
+	"title": "",
+	"skills": [],
+	"links": {},
+	"contributedBansos": ["xkiro-pro-7-hari"],
+	"hidden": false,
+	"joinedAt": "2026-08-08"
+}

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
-	"generatedAt": "2026-08-02",
-	"total": 84,
+	"generatedAt": "2026-08-08",
+	"total": 85,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -818,6 +818,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-17",
 			"contributorSlug": "akbar"
+		},
+		{
+			"id": "xkiro-pro-7-hari",
+			"title": "xKiro Pro Gratis 7 Hari — API AI Multi-Model",
+			"provider": "xKiro",
+			"status": "active",
+			"tags": ["AI", "API", "Free Trial"],
+			"featured": true,
+			"publishedAt": "2026-08-08",
+			"contributorSlug": "renyx"
 		},
 		{
 			"id": "zcode-glm-52-free",

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -865,7 +865,7 @@
 			"provider": "xKiro",
 			"status": "active",
 			"tags": ["AI", "API", "Free Trial"],
-			"featured": true,
+			"featured": false,
 			"publishedAt": "2026-08-08",
 			"contributorSlug": "renyx"
 		},

--- a/src/lib/data/bansos/xkiro-pro-7-hari/README.md
+++ b/src/lib/data/bansos/xkiro-pro-7-hari/README.md
@@ -1,0 +1,40 @@
+# ✅ xKiro Pro Gratis 7 Hari — API AI Multi-Model
+
+**Provider:** xKiro
+
+xKiro menyediakan satu API yang kompatibel dengan OpenAI dan Anthropic untuk mengakses berbagai model AI. Program referral ini menawarkan akses Pro gratis selama 7 hari sejak klaim menurut informasi kontributor.
+
+> **Status:** Aktif
+
+⏰ **Masa berlaku:** Akses Pro berlaku 7 hari sejak berhasil diklaim. Ketersediaan dan ketentuan referral mengikuti kebijakan xKiro.
+
+## Keuntungan
+
+- Akses Pro gratis selama 7 hari sejak berhasil diklaim
+- API kompatibel dengan OpenAI dan Anthropic
+- Akses berbagai model AI melalui satu API
+- 20+ model gratis tersedia di platform xKiro
+
+## Syarat dan Cara Klaim
+
+- Buka link referral xKiro
+- Daftar menggunakan akun baru dengan email dan password
+- Verifikasi email
+- Tautkan akun Telegram ke akun xKiro
+- Klaim Pro Plan melalui dashboard xKiro
+
+## Cara Klaim
+
+[🔗 Buka xKiro](https://xkiro.com/ref/JHEFXQM)
+
+## Catatan
+
+Akses Pro 7 hari berasal dari informasi referral kontributor; cek dashboard setelah klaim untuk memastikan benefit aktif.
+
+## Tags
+
+AI · API · Free Trial
+
+✏️ Dikontribusikan oleh `renyx`
+
+_[bansos.dev](https://bansos.dev) — Open Source Catalog_

--- a/src/lib/data/bansos/xkiro-pro-7-hari/index.json
+++ b/src/lib/data/bansos/xkiro-pro-7-hari/index.json
@@ -1,0 +1,32 @@
+{
+	"id": "xkiro-pro-7-hari",
+	"title": "xKiro Pro Gratis 7 Hari — API AI Multi-Model",
+	"provider": "xKiro",
+	"description": "xKiro menyediakan satu API yang kompatibel dengan OpenAI dan Anthropic untuk mengakses berbagai model AI. Program referral ini menawarkan akses Pro gratis selama 7 hari sejak klaim menurut informasi kontributor.",
+	"benefits": [
+		"Akses Pro gratis selama 7 hari sejak berhasil diklaim",
+		"API kompatibel dengan OpenAI dan Anthropic",
+		"Akses berbagai model AI melalui satu API",
+		"20+ model gratis tersedia di platform xKiro"
+	],
+	"requirements": [
+		"Buka link referral xKiro",
+		"Daftar menggunakan akun baru dengan email dan password",
+		"Verifikasi email",
+		"Tautkan akun Telegram ke akun xKiro",
+		"Klaim Pro Plan melalui dashboard xKiro"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Akses Pro berlaku 7 hari sejak berhasil diklaim; ketersediaan dan ketentuan referral mengikuti kebijakan xKiro"
+	},
+	"ctaLink": "https://xkiro.com/ref/JHEFXQM",
+	"tags": ["AI", "API", "Free Trial"],
+	"status": "active",
+	"featured": true,
+	"publishedAt": "2026-08-08",
+	"source": "https://xkiro.com/",
+	"providerWebsiteUrl": "https://xkiro.com/",
+	"tips": "Akses Pro 7 hari berasal dari informasi referral kontributor; cek dashboard setelah klaim untuk memastikan benefit aktif.",
+	"contributorSlug": "renyx"
+}

--- a/src/lib/data/bansos/xkiro-pro-7-hari/index.json
+++ b/src/lib/data/bansos/xkiro-pro-7-hari/index.json
@@ -23,7 +23,7 @@
 	"ctaLink": "https://xkiro.com/ref/JHEFXQM",
 	"tags": ["AI", "API", "Free Trial"],
 	"status": "active",
-	"featured": true,
+	"featured": false,
 	"publishedAt": "2026-08-08",
 	"source": "https://xkiro.com/",
 	"providerWebsiteUrl": "https://xkiro.com/",


### PR DESCRIPTION
## Summary

- Add the xKiro Pro 7-day referral listing credited to Renyx.
- Document xKiro's OpenAI/Anthropic-compatible API and multi-model access.
- Keep the listing out of Featured until the donation requirement is approved.

## Validation

- `npm run validate:data`
- `npm run check`
- Prettier check on changed JSON, Markdown, and generated LLM catalog files.
- Catalog assertion: 92 entries; xKiro, Qoder, InferX, and Xiaomi MiMo are all `featured: false`.