### PR TITLE
feat(bansos): tambah hcnsec Free ¥30K API Credit

### DIFF
--- a/src/lib/data/bansos/contributors/rafly0078/manifest.json
+++ b/src/lib/data/bansos/contributors/rafly0078/manifest.json
@@ -7,7 +7,7 @@
 	"links": {
 		"github": "https://github.com/Rafly0078"
 	},
-	"contributedBansos": ["gorouter-free-75-ai-credit"],
+	"contributedBansos": ["gorouter-free-75-ai-credit", "hcnsec-free-30k-api-credit"],
 	"hidden": false,
 	"joinedAt": "2026-07-29"
 }

--- a/src/lib/data/bansos/hcnsec-free-30k-api-credit/README.md
+++ b/src/lib/data/bansos/hcnsec-free-30k-api-credit/README.md
@@ -1,0 +1,38 @@
+# ✅ hcnsec Free ¥30K API Credit
+
+**Provider:** hcnsec
+
+hcnsec adalah gateway API LLM kompatibel format OpenAI yang memberi saldo kredit awal untuk pengguna baru yang mendaftar via email. Kredit dipakai untuk mengakses model open weight dan open source seperti DeepSeek V4-Flash, GLM-5.2, dan Qwen 3.6. Saldo tambahan bisa didapat lewat check-in harian dan program invite.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Ketersediaan dan besaran kredit mengikuti kebijakan hcnsec; provider mengumumkan penyesuaian harga dan kuota berkala
+
+## Keuntungan
+
+- Kredit API awal senilai ¥30K (satuan saldo platform, bukan mata uang)
+- Akses ke banyak model open weight dan open source
+- Kompatibel format OpenAI, bisa dipakai dari Claude Code, Cursor, dan tool sejenis
+- Saldo tambahan gratis via check-in harian dan program invite
+
+## Persyaratan
+
+- Daftar akun baru menggunakan email
+- Kredit gratis langsung tersedia di dashboard, siap dipakai lewat API key
+
+## Tips
+
+Model gratis adalah model parameter kecil dan diprioritaskan untuk pengujian. Provider menyarankan menjalankan task berat pada malam atau dini hari karena antrean siang hari padat dan tidak stabil. Cukup satu akun per orang: provider aktif menindak abuse.
+
+---
+
+[🔗 Klaim Bansos Ini](https://api.hcnsec.cn/sign-up?aff=w6I4)
+
+
+🏷️ Tags: AI Credits · API · AI Tools · Free Tier · Developer Tools
+
+✏️ Dikontribusikan oleh `rafly0078`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/hcnsec-free-30k-api-credit/README.md
+++ b/src/lib/data/bansos/hcnsec-free-30k-api-credit/README.md
@@ -18,7 +18,7 @@ hcnsec adalah gateway API LLM kompatibel format OpenAI yang memberi saldo kredit
 ## Persyaratan
 
 - Daftar akun baru menggunakan email
-- Kredit gratis langsung tersedia di dashboard, siap dipakai lewat API key
+- Periksa saldo kredit di dashboard setelah pendaftaran; ketersediaan kredit dan jumlahnya mengikuti kebijakan hcnsec
 
 ## Tips
 

--- a/src/lib/data/bansos/hcnsec-free-30k-api-credit/index.json
+++ b/src/lib/data/bansos/hcnsec-free-30k-api-credit/index.json
@@ -1,0 +1,28 @@
+{
+	"id": "hcnsec-free-30k-api-credit",
+	"title": "hcnsec Free ¥30K API Credit",
+	"provider": "hcnsec",
+	"description": "hcnsec adalah gateway API LLM kompatibel format OpenAI yang memberi saldo kredit awal untuk pengguna baru yang mendaftar via email. Kredit dipakai untuk mengakses model open weight dan open source seperti DeepSeek V4-Flash, GLM-5.2, dan Qwen 3.6. Saldo tambahan bisa didapat lewat check-in harian.",
+	"benefits": [
+		"Kredit API awal senilai ¥30K (satuan saldo platform, bukan mata uang)",
+		"Akses ke banyak model open weight dan open source",
+		"Kompatibel format OpenAI, bisa dipakai dari Claude Code, Cursor, dan tool sejenis",
+		"Saldo tambahan gratis via check-in harian dan program invite"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Ketersediaan dan besaran kredit mengikuti kebijakan hcnsec; provider mengumumkan penyesuaian harga dan kuota berkala"
+	},
+	"requirements": [
+		"Daftar akun baru menggunakan email",
+		"Kredit gratis langsung tersedia di dashboard, siap dipakai lewat API key"
+	],
+	"ctaLink": "https://api.hcnsec.cn/sign-up?aff=w6I4",
+	"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-09",
+	"tips": "Model gratis adalah model parameter kecil dan diprioritaskan untuk pengujian. Provider menyarankan menjalankan task berat pada malam atau dini hari karena antrean siang hari padat dan tidak stabil. Cukup satu akun per orang: provider aktif menindak abuse.",
+	"source": "https://api.hcnsec.cn/",
+	"contributorSlug": "rafly0078"
+}

--- a/src/lib/data/bansos/hcnsec-free-30k-api-credit/index.json
+++ b/src/lib/data/bansos/hcnsec-free-30k-api-credit/index.json
@@ -15,7 +15,7 @@
 	},
 	"requirements": [
 		"Daftar akun baru menggunakan email",
-		"Kredit gratis langsung tersedia di dashboard, siap dipakai lewat API key"
+		"Periksa saldo kredit di dashboard setelah pendaftaran; ketersediaan kredit dan jumlahnya mengikuti kebijakan hcnsec"
 	],
 	"ctaLink": "https://api.hcnsec.cn/sign-up?aff=w6I4",
 	"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-02",
-	"total": 84,
+	"total": 85,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -359,6 +359,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-20",
 			"contributorSlug": "brian"
+		},
+		{
+			"id": "hcnsec-free-30k-api-credit",
+			"title": "hcnsec Free ¥30K API Credit",
+			"provider": "hcnsec",
+			"status": "active",
+			"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+			"featured": false,
+			"publishedAt": "2026-08-09",
+			"contributorSlug": "rafly0078"
 		},
 		{
 			"id": "idwebhost-claim-domain-gratis-myid-juli2026",

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-08-02",
+	"generatedAt": "2026-08-10",
 	"total": 85,
 	"items": [
 		{


### PR DESCRIPTION
## Ringkasan

Menambahkan listing baru: **hcnsec Free ¥30K API Credit** — gateway API LLM kompatibel format OpenAI yang memberi saldo kredit awal untuk pengguna baru yang mendaftar via email.

Kontributor: `rafly0078` (profil sudah ada, ditambahkan ke `contributedBansos`).

## Sumber dan verifikasi

| Klaim | Status |
|---|---|
| Domain dan halaman sign-up hidup | ✅ HTTP 200 (`https://api.hcnsec.cn/sign-up`) |
| Badan usaha | ✅ 新疆幻城网安科技有限责任公司, tercantum di halaman About + JSON-LD |
| Model DeepSeek V4-Flash, GLM-5.2, Qwen 3.6 | ✅ Disebut di pengumuman resmi (`/api/status`) |
| Kompatibel OpenAI + Claude Code/Cursor | ✅ Meta description situs resmi |
| Saldo tambahan via check-in dan invite | ✅ Pengumuman resmi #15 |
| **Besaran kredit awal ¥30K** | ⚠️ **Tidak terverifikasi** — endpoint harga butuh login |

## Catatan untuk reviewer

**1. Besaran kredit tidak terverifikasi.** Angka ¥30K berasal dari pengalaman kontributor, bukan halaman resmi — `/api/pricing` dan `/api/models` menolak akses tanpa login. Karena itu `validity.type` diisi `uncertain` dan deskripsi tidak menjanjikan angka pasti. Silakan turunkan/hapus klaim angka kalau dirasa terlalu kuat.

**2. `ctaLink` memakai parameter referral kontributor** (`?aff=w6I4`). Mengacu aturan referral di CONTRIBUTING, listing ini berlaku satu bulan sejak `publishedAt` (2026-08-09). Kalau kebijakannya berbeda, saya siap ganti ke link non-referral.

**3. Provider transparan soal keterbatasan.** Pengumuman resmi menyebut model gratis adalah model parameter kecil untuk pengujian, dan antrean siang hari padat. Ini sudah saya tulis apa adanya di `tips` supaya ekspektasi pengguna realistis.

**4. Bukan violation.** Kredit dibagikan resmi oleh provider sebagai program publik (self-declared 公益/nirlaba), bukan hasil bypass atau eksploitasi. Syarat klaimnya wajar (registrasi email), dan provider aktif menindak abuse multi-akun — sudah dicatat di `tips` agar pengguna tidak melanggar ToS.

## Validasi

- \`npm run validate:data\` ✅
- \`npm run check\` ✅ (svelte-check: 0 error, 0 warning)
- \`npm run lint\` ✅ (eslint bersih; prettier hanya warning CRLF yang sudah ada di tree upstream, file baru saya lolos)
- \`npm run build\` ⚠️ tidak selesai di lokal (Windows, timeout) — mengandalkan CI. Perubahan ini murni data listing.

\`static/llms*.txt\` sengaja tidak ikut di-commit karena regenerasinya menarik perubahan dari listing lain yang belum ter-update di upstream; \`postbuild\` akan meregenerasi saat deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an active promotion offering ¥30K in API credits for eligible new users.
  * Provides OpenAI-compatible access to open-source models, daily check-ins, and invite rewards.
  * Includes signup details, eligibility information, usage tips, tags, source, and validity notes.
  * Updated the available promotion count from 84 to 85.
  * Refreshed the promotion catalog metadata and added contributor attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->