### PR TITLE
feat: tambah listing TaBiAI Free $100 Credit + $20 Bonus Referral

### DIFF
--- a/src/lib/data/bansos/contributors/syafii-fahreza/manifest.json
+++ b/src/lib/data/bansos/contributors/syafii-fahreza/manifest.json
@@ -11,6 +11,7 @@
 		"futureppo-free-credit",
 		"modelset-free-credit",
 		"seekai-free-200-ai-credit",
+		"tabiai-free-100-credit",
 		"tokenfaucet-daily-free-tokens",
 		"vsllm-daily-checkin-rewards",
 		"vyce-ai-free-40-credit"

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-02",
-	"total": 84,
+	"total": 85,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -698,6 +698,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-17",
 			"contributorSlug": "devers"
+		},
+		{
+			"id": "tabiai-free-100-credit",
+			"title": "TaBiAI Free $100 Credit + $20 Bonus Referral",
+			"provider": "TaBiAI",
+			"status": "active",
+			"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+			"featured": false,
+			"publishedAt": "2026-08-10",
+			"contributorSlug": "syafii-fahreza"
 		},
 		{
 			"id": "tencent-cloud-free-tier",

--- a/src/lib/data/bansos/tabiai-free-100-credit/README.md
+++ b/src/lib/data/bansos/tabiai-free-100-credit/README.md
@@ -1,0 +1,42 @@
+# ✅ TaBiAI Free $100 Credit + $20 Bonus Referral
+
+**Provider:** TaBiAI
+
+TaBiAI adalah gateway API berbasis New API yang khusus menyalurkan model Claude Opus lewat endpoint kompatibel Anthropic dan OpenAI. Setiap akun baru menerima kredit $100 secara otomatis, ditambah $20 lagi bila mendaftar memakai kode undangan, sehingga totalnya $120. Tersedia juga check-in harian yang memberi tambahan kredit dengan nominal acak. Katalog modelnya sengaja sempit: hanya Claude Opus 4.8 dan Claude Opus 5 beserta varian thinking, dan keempatnya sudah bisa dipakai oleh grup default tanpa perlu naik tingkat.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Layanan sangat baru dan belum memiliki ketentuan layanan tertulis; besaran bonus maupun ketersediaannya bisa berubah atau berhenti sewaktu-waktu
+
+## Keuntungan
+
+- Kredit $100 otomatis untuk setiap akun baru, tanpa kartu kredit
+- Tambahan kredit $20 khusus pendaftar yang memakai kode undangan, sehingga totalnya menjadi $120
+- Check-in harian yang menambah kredit dengan nominal acak; satu contoh nyata bernilai $9,73 dalam sekali klaim
+- Akses Claude Opus 5 dan Claude Opus 4.8 beserta varian thinking, dengan tarif $3 per satu juta token masukan dan keluaran untuk Opus 5, serta $1 masukan dan $5 keluaran untuk Opus 4.8
+- Endpoint ganda: Anthropic-native /v1/messages yang bisa langsung dipakai Claude Code, dan kompatibel OpenAI /v1/chat/completions untuk Codex, Cline, dan tool sejenis
+
+## Persyaratan
+
+- Daftar lewat tautan undangan agar tambahan kredit $20 ikut masuk ke akun
+- Gunakan akun GitHub karena pendaftaran dengan kata sandi dimatikan di sisi server
+- Selesaikan verifikasi Cloudflare Turnstile saat membuat akun
+- Buat API key di menu Console sebelum mulai memanggil model
+- Lakukan check-in harian di dashboard untuk mengambil kredit tambahan
+
+## Tips
+
+Prompt caching tidak berfungsi di gateway ini. Satu sesi Claude Code yang diuji mencatat 5,67 juta token masukan dengan cache_creation dan cache_read tetap nol, sehingga konteks yang sama dibayar penuh pada setiap giliran dan sesi itu saja menghabiskan sekitar $17 atau 14 persen dari kredit $120. Untuk pekerjaan berkonteks besar, kredit di sini terbakar jauh lebih cepat daripada di gateway yang mendukung cache. Layanan juga masih sangat baru: domainnya baru didaftarkan 4 Agustus 2026, belum ada ketentuan layanan maupun kebijakan privasi, tidak ada pengumuman resmi, dan monitor uptime bawaan situsnya masih kosong. Hindari memakainya untuk beban kerja produksi, dan sebaiknya jangan mengisi saldo sebelum layanan terbukti bertahan.
+
+---
+
+[🔗 Klaim Bansos Ini](https://tabitoken.com/sign-up?aff=fryg)
+
+
+🏷️ Tags: AI Credits · API · AI Tools · Free Tier · Developer Tools
+
+✏️ Dikontribusikan oleh `syafii-fahreza`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/tabiai-free-100-credit/index.json
+++ b/src/lib/data/bansos/tabiai-free-100-credit/index.json
@@ -1,0 +1,32 @@
+{
+	"id": "tabiai-free-100-credit",
+	"title": "TaBiAI Free $100 Credit + $20 Bonus Referral",
+	"provider": "TaBiAI",
+	"description": "TaBiAI adalah gateway API berbasis New API yang khusus menyalurkan model Claude Opus lewat endpoint kompatibel Anthropic dan OpenAI. Setiap akun baru menerima kredit $100 secara otomatis, ditambah $20 lagi bila mendaftar memakai kode undangan, sehingga totalnya $120. Tersedia juga check-in harian yang memberi tambahan kredit dengan nominal acak. Katalog modelnya sengaja sempit: hanya Claude Opus 4.8 dan Claude Opus 5 beserta varian thinking, dan keempatnya sudah bisa dipakai oleh grup default tanpa perlu naik tingkat.",
+	"benefits": [
+		"Kredit $100 otomatis untuk setiap akun baru, tanpa kartu kredit",
+		"Tambahan kredit $20 khusus pendaftar yang memakai kode undangan, sehingga totalnya menjadi $120",
+		"Check-in harian yang menambah kredit dengan nominal acak; satu contoh nyata bernilai $9,73 dalam sekali klaim",
+		"Akses Claude Opus 5 dan Claude Opus 4.8 beserta varian thinking, dengan tarif $3 per satu juta token masukan dan keluaran untuk Opus 5, serta $1 masukan dan $5 keluaran untuk Opus 4.8",
+		"Endpoint ganda: Anthropic-native /v1/messages yang bisa langsung dipakai Claude Code, dan kompatibel OpenAI /v1/chat/completions untuk Codex, Cline, dan tool sejenis"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Layanan sangat baru dan belum memiliki ketentuan layanan tertulis; besaran bonus maupun ketersediaannya bisa berubah atau berhenti sewaktu-waktu"
+	},
+	"requirements": [
+		"Daftar lewat tautan undangan agar tambahan kredit $20 ikut masuk ke akun",
+		"Gunakan akun GitHub karena pendaftaran dengan kata sandi dimatikan di sisi server",
+		"Selesaikan verifikasi Cloudflare Turnstile saat membuat akun",
+		"Buat API key di menu Console sebelum mulai memanggil model",
+		"Lakukan check-in harian di dashboard untuk mengambil kredit tambahan"
+	],
+	"ctaLink": "https://tabitoken.com/sign-up?aff=fryg",
+	"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-10",
+	"tips": "Prompt caching tidak berfungsi di gateway ini. Satu sesi Claude Code yang diuji mencatat 5,67 juta token masukan dengan cache_creation dan cache_read tetap nol, sehingga konteks yang sama dibayar penuh pada setiap giliran dan sesi itu saja menghabiskan sekitar $17 atau 14 persen dari kredit $120. Untuk pekerjaan berkonteks besar, kredit di sini terbakar jauh lebih cepat daripada di gateway yang mendukung cache. Layanan juga masih sangat baru: domainnya baru didaftarkan 4 Agustus 2026, belum ada ketentuan layanan maupun kebijakan privasi, tidak ada pengumuman resmi, dan monitor uptime bawaan situsnya masih kosong. Hindari memakainya untuk beban kerja produksi, dan sebaiknya jangan mengisi saldo sebelum layanan terbukti bertahan.",
+	"source": "https://tabitoken.com/pricing",
+	"contributorSlug": "syafii-fahreza"
+}


### PR DESCRIPTION
## Ringkasan

Menambahkan satu listing baru: **TaBiAI** (`tabitoken.com`), gateway API berbasis [New API](https://github.com/QuantumNous/new-api) yang khusus menyalurkan model Claude Opus lewat endpoint kompatibel Anthropic dan OpenAI.

- Akun baru menerima **kredit $100 otomatis**
- **+$20 tambahan untuk pendaftar** yang memakai kode undangan (total $120)
- **Check-in harian** dengan nominal acak

Kode undangan di `ctaLink` adalah milik kontributor, sesuai § "Aturan referral" di `CONTRIBUTING.md`.

## Bukti struktur bonus

Diverifikasi dari log sistem akun kontributor setelah mendaftar (10 Agustus 2026):

```
07:49:17  System  新用户注册赠送 $100.000000 额度
07:49:17  System  使用邀请码赠送 $20.000000 额度
07:49:52  System  用户签到，获得额度 $9.739868 额度
```

Pembagiannya ditulis eksplisit di `description`, `benefits`, dan `requirements` supaya tidak menyesatkan: **$100 diterima semua akun baru tanpa kode undangan**, dan kode undangan hanya menambah $20 bagi pendaftar.

## Fakta teknis dari endpoint publik penyedia

Dari `/api/status` dan `/api/pricing` (`source` memakai halaman Model Square yang menampilkan katalog dan tarif):

- Katalog hanya 4 model: `claude-opus-4-8`, `claude-opus-4-8-thinking` ($1 masukan / $5 keluaran per 1M) dan `claude-opus-5`, `claude-opus-5-thinking` ($3 / $3 per 1M). `enable_groups` memuat `default`, jadi akun baru bisa langsung memakainya
- `password_register_enabled: false` dengan `github_oauth: true` → pendaftaran hanya lewat GitHub OAuth; ini dicantumkan di `requirements` karena form kata sandi di halaman sign-up tidak berfungsi
- `checkin_enabled: true` mengonfirmasi fitur check-in harian
- Endpoint: `/v1/messages` (Anthropic-native) dan `/v1/chat/completions` (kompatibel OpenAI)

## Ketidakpastian yang saya cantumkan apa adanya

`validity.type` diset `uncertain`, dan `tips` memuat peringatan berikut:

- **Prompt caching tidak berfungsi.** Satu sesi Claude Code lewat gateway ini mencatat 5,67 juta token masukan dengan `cache_creation_input_tokens` dan `cache_read_input_tokens` tetap nol sepanjang 61 respons. Konteks yang sama dibayar penuh tiap giliran, dan sesi itu saja menghabiskan sekitar $17 atau 14% dari kredit $120
- Domain baru didaftarkan **4 Agustus 2026** (RDAP Verisign), dan proses server tercatat baru dimulai 9 Agustus
- Belum ada ketentuan layanan maupun kebijakan privasi (`user_agreement_enabled` dan `privacy_policy_enabled` dua-duanya `false`), tidak ada pengumuman resmi, dan monitor uptime bawaan situs masih kosong
- Tidak ada liputan pihak ketiga yang bisa saya temukan, baik dalam bahasa Inggris maupun Mandarin

Karena itu listing ini menyarankan pemakaian non-produksi dan tidak menganjurkan pengisian saldo.

## Validasi

| Perintah | Hasil |
| --- | --- |
| `npm run validate:data` | `Validated 85 bansos folders and contributor references` |
| `prettier --check` (berkas PR) | `All matched files use Prettier code style!` |
| `eslint .` | 0 masalah |
| `svelte-check` | `0 errors and 0 warnings` |

`npm run build` tidak dijalankan: perubahan ini murni data listing tanpa sentuhan rendering atau SEO, dan `index.json` katalog diperbarui lewat `npm run add:bansos`. Di lingkungan lokal saya (Termux/Android) `build` juga tidak bisa jalan karena `@resvg/resvg-js` tidak punya prebuilt. `commit-history.json` sengaja saya kembalikan ke kondisi `main` agar diff tetap fokus.

Kontributor: `syafii-fahreza` (profil sudah ada, `contributedBansos` diperbarui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a TaBiAI offer providing $100 in free credits for new signups.
  * Included a $20 referral bonus and daily check-in rewards.
  * Added details about supported Claude models, API endpoints, requirements, pricing, and service limitations.
* **Documentation**
  * Added usage guidance, service-status notes, referral information, tags, and contributor attribution.
  * Updated the available offer count to 85.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->