### PR TITLE
feat(bansos): tambah MODELOC Invite 100k Compute (≈ $10)

### DIFF
--- a/src/lib/data/bansos/contributors/rafly0078/manifest.json
+++ b/src/lib/data/bansos/contributors/rafly0078/manifest.json
@@ -10,6 +10,7 @@
 	"contributedBansos": [
 		"gorouter-free-75-ai-credit",
 		"hcnsec-free-30k-api-credit",
+		"modeloc-invite-100k-compute",
 		"tabiai-free-120-api-credit"
 	],
 	"hidden": false,

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-10",
-	"total": 87,
+	"total": 88,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -519,6 +519,16 @@
 			"featured": false,
 			"publishedAt": "2026-07-06",
 			"contributorSlug": "mugi-wiguna"
+		},
+		{
+			"id": "modeloc-invite-100k-compute",
+			"title": "MODELOC Invite — 100k Compute (≈ $10) untuk Akun Baru",
+			"provider": "MODELOC",
+			"status": "active",
+			"tags": ["AI Credits", "API", "LLM", "Referral"],
+			"featured": false,
+			"publishedAt": "2026-08-14",
+			"contributorSlug": "rafly0078"
 		},
 		{
 			"id": "modelset-free-credit",

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,5 +1,5 @@
 {
-	"generatedAt": "2026-08-10",
+	"generatedAt": "2026-08-16",
 	"total": 88,
 	"items": [
 		{

--- a/src/lib/data/bansos/modeloc-invite-100k-compute/README.md
+++ b/src/lib/data/bansos/modeloc-invite-100k-compute/README.md
@@ -19,7 +19,8 @@ MODELOC adalah platform compute pool sekaligus pendeteksi keaslian model. Daftar
 
 - Daftar akun baru MODELOC lewat link invite (reward khusus pendaftaran baru, akun lama tidak dapat)
 - Selesaikan proses sign up sampai masuk console, compute masuk otomatis tanpa klaim manual
-- Pakai compute buat model call lewat halaman Compute Pool atau API key MODELOC
+- Login dan gabung ke Compute Pool sekali sebelum melakukan model call
+- Gunakan API key MODELOC berawalan sk_ atau buat pool key berawalan pk_ sebelum melakukan model call
 
 ## Tips
 

--- a/src/lib/data/bansos/modeloc-invite-100k-compute/README.md
+++ b/src/lib/data/bansos/modeloc-invite-100k-compute/README.md
@@ -1,0 +1,39 @@
+# ✅ MODELOC Invite — 100k Compute (≈ $10) untuk Akun Baru
+
+**Provider:** MODELOC
+
+MODELOC adalah platform compute pool sekaligus pendeteksi keaslian model. Daftar akun baru lewat link invite dan langsung dapat 100.000 compute (≈ $10 kuota pemakaian) buat manggil 100+ LLM seperti Claude, GPT, dan Gemini via gateway OpenAI-compatible.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** MODELOC tidak mencantumkan tanggal berakhir program invite; reward hanya berlaku untuk pendaftaran akun baru
+
+## Keuntungan
+
+- 100.000 compute (≈ $10 kuota pemakaian) otomatis masuk ke saldo setelah daftar via link invite
+- Compute bisa langsung dipakai manggil 100+ LLM (Claude / GPT / Gemini) lewat satu gateway OpenAI-compatible, pay-as-you-go
+- Sekalian akses fitur platform lain: deteksi konsistensi model, leaderboard dan review relay, plus Audit API dan Data API dengan satu API key
+- Setelah gabung kamu dapat link invite sendiri dan menurut MODELOC kedua pihak sama-sama dapat compute
+
+## Persyaratan
+
+- Daftar akun baru MODELOC lewat link invite (reward khusus pendaftaran baru, akun lama tidak dapat)
+- Selesaikan proses sign up sampai masuk console, compute masuk otomatis tanpa klaim manual
+- Pakai compute buat model call lewat halaman Compute Pool atau API key MODELOC
+
+## Tips
+
+Cek dulu nominal reward di halaman invite sebelum daftar karena MODELOC bisa mengubah besaran compute tanpa pengumuman. Saldo bisa dipantau di menu Compute balance pada dashboard.
+
+---
+
+[🔗 Klaim Bansos Ini](https://modeloc.com/i/ZX8EV9R5)
+
+
+🏷️ Tags: AI Credits · API · LLM · Referral
+
+✏️ Dikontribusikan oleh `rafly0078`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/modeloc-invite-100k-compute/index.json
+++ b/src/lib/data/bansos/modeloc-invite-100k-compute/index.json
@@ -16,7 +16,8 @@
 	"requirements": [
 		"Daftar akun baru MODELOC lewat link invite (reward khusus pendaftaran baru, akun lama tidak dapat)",
 		"Selesaikan proses sign up sampai masuk console, compute masuk otomatis tanpa klaim manual",
-		"Pakai compute buat model call lewat halaman Compute Pool atau API key MODELOC"
+		"Login dan gabung ke Compute Pool sekali sebelum melakukan model call",
+		"Gunakan API key MODELOC berawalan sk_ atau buat pool key berawalan pk_ sebelum melakukan model call"
 	],
 	"ctaLink": "https://modeloc.com/i/ZX8EV9R5",
 	"tags": ["AI Credits", "API", "LLM", "Referral"],

--- a/src/lib/data/bansos/modeloc-invite-100k-compute/index.json
+++ b/src/lib/data/bansos/modeloc-invite-100k-compute/index.json
@@ -1,0 +1,30 @@
+{
+	"id": "modeloc-invite-100k-compute",
+	"title": "MODELOC Invite — 100k Compute (≈ $10) untuk Akun Baru",
+	"provider": "MODELOC",
+	"description": "MODELOC adalah platform compute pool sekaligus pendeteksi keaslian model. Daftar akun baru lewat link invite dan langsung dapat 100.000 compute (≈ $10 kuota pemakaian) buat manggil 100+ LLM seperti Claude, GPT, dan Gemini via gateway OpenAI-compatible.",
+	"benefits": [
+		"100.000 compute (≈ $10 kuota pemakaian) otomatis masuk ke saldo setelah daftar via link invite",
+		"Compute bisa langsung dipakai manggil 100+ LLM (Claude / GPT / Gemini) lewat satu gateway OpenAI-compatible, pay-as-you-go",
+		"Sekalian akses fitur platform lain: deteksi konsistensi model, leaderboard dan review relay, plus Audit API dan Data API dengan satu API key",
+		"Setelah gabung kamu dapat link invite sendiri dan menurut MODELOC kedua pihak sama-sama dapat compute"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "MODELOC tidak mencantumkan tanggal berakhir program invite; reward hanya berlaku untuk pendaftaran akun baru"
+	},
+	"requirements": [
+		"Daftar akun baru MODELOC lewat link invite (reward khusus pendaftaran baru, akun lama tidak dapat)",
+		"Selesaikan proses sign up sampai masuk console, compute masuk otomatis tanpa klaim manual",
+		"Pakai compute buat model call lewat halaman Compute Pool atau API key MODELOC"
+	],
+	"ctaLink": "https://modeloc.com/i/ZX8EV9R5",
+	"tags": ["AI Credits", "API", "LLM", "Referral"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-14",
+	"tips": "Cek dulu nominal reward di halaman invite sebelum daftar karena MODELOC bisa mengubah besaran compute tanpa pengumuman. Saldo bisa dipantau di menu Compute balance pada dashboard.",
+	"source": "https://modeloc.com/pool",
+	"providerWebsiteUrl": "https://modeloc.com",
+	"contributorSlug": "rafly0078"
+}


### PR DESCRIPTION
## Ringkas Perubahan

Menambahkan listing **MODELOC Invite — 100k Compute (≈ $10) untuk Akun Baru** (`modeloc-invite-100k-compute`), atribusi ke contributor `rafly0078`.

MODELOC adalah platform compute pool sekaligus pendeteksi keaslian model (deteksi relay yang menurunkan/menukar model, leaderboard relay, gateway OpenAI-compatible ke 100+ LLM). Akun baru yang daftar lewat link invite langsung dapat 100.000 compute (≈ $10 kuota pemakaian).

File yang berubah (4):

- `src/lib/data/bansos/modeloc-invite-100k-compute/index.json` + `README.md` (baru, README hasil generate script)
- `src/lib/data/bansos/index.json` (catalog index, 87 → 88)
- `src/lib/data/bansos/contributors/rafly0078/manifest.json` (`contributedBansos`)

`commit-history.json` sengaja tidak ikut di-commit karena churn-nya cuma provenance listing lain (aisure, hcnsec, tabiai, tokenharbor) dan file itu regenerate otomatis di `prebuild`.

## Sumber & Verifikasi

Data diambil dari halaman invite resmi MODELOC, bukan klaim komunitas:

- Endpoint publik `https://modeloc.com/invite/info/ZX8EV9R5` → `{"valid":true,"inviter":{"name":"Rafly0078"},"reward":"100000","reward_enabled":true,"reward_usd":"10"}`
- Copy resmi di halaman invite: `Sign up and get {n} compute (≈ ${u} of usage)` dan `Invite rewards are for new sign-ups only`
- Fitur platform diambil dari copy resmi halaman invite: model consistency check, relay leaderboard & reviews, compute pool 100+ model (Claude / GPT / Gemini, OpenAI-compatible, pay-as-you-go), share quota, open platform API
- `ctaLink` memakai link referral contributor (sesuai aturan referral di CONTRIBUTING, berlaku 1 bulan sejak `publishedAt`), `source` diarahkan ke halaman program `https://modeloc.com/pool`
- `providerWebsiteUrl` diisi `https://modeloc.com` supaya favicon provider ke-resolve dari domain utama, bukan dari URL invite

### Ketidakpastian

- Provider tidak mencantumkan tanggal berakhir program invite, jadi `validity.type` = `uncertain`.
- Copy MODELOC menyebut "both sides earn credits", tapi nominal yang bisa diverifikasi dari endpoint publik hanya reward sisi pendaftar baru (100.000 compute ≈ $10). Karena itu benefit sisi inviter ditulis sebagai klaim provider, bukan angka pasti.
- Nominal reward bisa diubah provider tanpa pengumuman; sudah diberi catatan di `tips`.

## Checklist

- [x] Bahasa dan copy sudah konsisten.
- [x] SEO tag dan metadata tetap valid.
- [x] Tidak menghapus konten utama.
- [x] Link dan format markdown valid.

## Uji Singkat

- [x] `npm run validate:data` → `Validated 88 bansos folders and contributor references`
- [x] `npm run check` → `382 FILES 0 ERRORS 0 WARNINGS`
- [x] `npx prettier --check` pada semua file yang disentuh → lolos
- [x] Pratinjau halaman: dev server → `/list/modeloc-invite-100k-compute/` **200**, shortlink `/modeloc-invite-100k-compute` → redirect ke detail **200**, `og.png` **200** (PNG 69 KB), `/providers/modeloc` **200**, `/rafly0078` **200**
- [x] Tidak ada regresi: diff cuma nambah satu listing, tidak menyentuh route/komponen

### Catatan soal `npm run build` dan `npm run lint`

Dua-duanya gagal di working copy saya karena sebab yang sudah ada sebelum perubahan ini, bukan karena listing baru:

- `npm run build` berhenti di prerender dengan `Error: 404 /rafly/ (linked from /rafly)`. Penyebabnya `commit-contributors.json` (gitignored, hasil generate dari git history lokal) memetakan author commit `gorouter-free-75-ai-credit` ke git login `rafly`, sedangkan profil contributor yang ada `rafly0078`; `src/routes/list/[id]/+page.svelte` fallback ke `/{login}` kalau profil tidak ketemu. Sudah saya reproduksi di tree `upstream/main` bersih tanpa listing ini.
- `npm run lint` melaporkan 201 file bermasalah termasuk file yang tidak disentuh (`tsconfig.json`, `vite.config.ts`, semua route). Repo tidak punya `.gitattributes` dan `.prettierrc` tidak set `endOfLine`, jadi checkout CRLF di Windows bentrok dengan default `lf` prettier. Saya tidak menjalankan `npm run format` supaya PR ini tidak bawa diff ~200 file yang tidak relevan.

Kalau maintainer mau, dua hal itu bisa saya angkat jadi issue/PR terpisah.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an active MODELOC invite offer providing 100,000 compute credits to eligible new accounts.
  * Included eligibility requirements, supported features, usage guidance, validity details, and the referral link.
  * Updated the available offer count from 87 to 88.
* **Documentation**
  * Added documentation and source attribution for the MODELOC invite program.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->