### PR TITLE
Add God Router free $50 credit + $30 referral bonus

### DIFF
--- a/src/lib/data/bansos/contributors/syafii-fahreza/manifest.json
+++ b/src/lib/data/bansos/contributors/syafii-fahreza/manifest.json
@@ -9,6 +9,7 @@
 		"aerolink-starter-free-trial",
 		"ai-hub-free-plan",
 		"futureppo-free-credit",
+		"godrouter-free-50-credit",
 		"modelset-free-credit",
 		"seekai-free-200-ai-credit",
 		"tokenfaucet-daily-free-tokens",

--- a/src/lib/data/bansos/godrouter-free-50-credit/README.md
+++ b/src/lib/data/bansos/godrouter-free-50-credit/README.md
@@ -1,0 +1,40 @@
+# ✅ God Router Free $50 AI Credit + $30 Bonus Referral
+
+**Provider:** God Router
+
+God Router adalah gateway AI kompatibel OpenAI yang menyatukan 26 model frontier di satu endpoint. Setiap akun baru menerima kredit $50, dan pendaftar yang memakai kode undangan mendapat tambahan $30 sehingga saldo awalnya menjadi $80. Kredit bisa dipakai untuk Claude Opus 5, Claude Fable 5, GPT-5.6, Gemini 3 Pro, Grok 4.5, DeepSeek V4, dan lainnya tanpa langganan bulanan. Nilai bonus ini tidak diumumkan di halaman mana pun; angkanya hanya muncul di log dashboard setelah akun dibuat.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Layanan masih sangat baru dan promo bisa berubah sewaktu-waktu; nilai bonus tidak diumumkan di situs dan hanya tercatat di log dashboard setelah pendaftaran
+
+## Keuntungan
+
+- Kredit $50 untuk setiap akun baru, tanpa kartu kredit
+- Tambahan $30 khusus pendaftar yang memakai kode undangan, jadi saldo awal lewat tautan referral menjadi $80
+- Akses 26 model lewat satu endpoint kompatibel OpenAI, termasuk Claude Opus 5, Claude Fable 5, Claude Sonnet 5, GPT-5.6, Gemini 3 Pro, Grok 4.5, DeepSeek V4, GLM 5.2, dan MiniMax M3
+- Semua model berada di grup default sehingga akun baru langsung bisa memakainya tanpa naik tingkat
+- Registrasi terbuka dengan email dan kata sandi, tanpa wajib akun GitHub
+
+## Persyaratan
+
+- Daftar lewat tautan undangan agar bonus $30 ikut masuk karena tanpa kode undangan saldo hanya $50
+- Verifikasi alamat email memakai kode OTP saat pendaftaran
+- Buat API key di dashboard lalu arahkan klien ke https://godrouter.cyou/v1
+
+## Tips
+
+Bonus $30 hanya masuk kalau kamu mendaftar memakai kode undangan; tanpa kode undangan saldo awal cuma $50. Kredit ini cepat susut karena diskon prompt caching tidak diterapkan: pada pengujian 18 Agustus 2026 satu permintaan berisi 21.291 token masukan ditagih penuh $0,32 dengan tarif Claude Opus 5 $15 per 1 juta token masukan dan $15 per 1 juta token keluaran, sehingga satu sesi agen pengoding yang panjang bisa menghabiskan saldo dalam hitungan jam. Tidak ada check-in harian, jadi saldo tidak bertambah setelah bonus awal. Domain baru terdaftar 3 Agustus 2026 dan instance-nya masih menampilkan versi v1.0.0 dengan monitor uptime kosong, jadi jangan pakai untuk beban kerja produksi dan jangan kirim data sensitif; permintaan dirakit ulang di sisi server gateway dan pada pengujian yang sama ada blok instruksi tambahan yang ikut tersisip ke dalam percakapan.
+
+---
+
+[🔗 Klaim Bansos Ini](https://godrouter.cyou/sign-up?aff=k1fy)
+
+
+🏷️ Tags: AI Credits · API · AI Tools · Free Tier · Developer Tools
+
+✏️ Dikontribusikan oleh `syafii-fahreza`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/godrouter-free-50-credit/index.json
+++ b/src/lib/data/bansos/godrouter-free-50-credit/index.json
@@ -1,0 +1,30 @@
+{
+	"id": "godrouter-free-50-credit",
+	"title": "God Router Free $50 AI Credit + $30 Bonus Referral",
+	"provider": "God Router",
+	"description": "God Router adalah gateway AI kompatibel OpenAI yang menyatukan 26 model frontier di satu endpoint. Setiap akun baru menerima kredit $50, dan pendaftar yang memakai kode undangan mendapat tambahan $30 sehingga saldo awalnya menjadi $80. Kredit bisa dipakai untuk Claude Opus 5, Claude Fable 5, GPT-5.6, Gemini 3 Pro, Grok 4.5, DeepSeek V4, dan lainnya tanpa langganan bulanan. Nilai bonus ini tidak diumumkan di halaman mana pun; angkanya hanya muncul di log dashboard setelah akun dibuat.",
+	"benefits": [
+		"Kredit $50 untuk setiap akun baru, tanpa kartu kredit",
+		"Tambahan $30 khusus pendaftar yang memakai kode undangan, jadi saldo awal lewat tautan referral menjadi $80",
+		"Akses 26 model lewat satu endpoint kompatibel OpenAI, termasuk Claude Opus 5, Claude Fable 5, Claude Sonnet 5, GPT-5.6, Gemini 3 Pro, Grok 4.5, DeepSeek V4, GLM 5.2, dan MiniMax M3",
+		"Semua model berada di grup default sehingga akun baru langsung bisa memakainya tanpa naik tingkat",
+		"Registrasi terbuka dengan email dan kata sandi, tanpa wajib akun GitHub"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Layanan masih sangat baru dan promo bisa berubah sewaktu-waktu; nilai bonus tidak diumumkan di situs dan hanya tercatat di log dashboard setelah pendaftaran"
+	},
+	"requirements": [
+		"Daftar lewat tautan undangan agar bonus $30 ikut masuk karena tanpa kode undangan saldo hanya $50",
+		"Verifikasi alamat email memakai kode OTP saat pendaftaran",
+		"Buat API key di dashboard lalu arahkan klien ke https://godrouter.cyou/v1"
+	],
+	"ctaLink": "https://godrouter.cyou/sign-up?aff=k1fy",
+	"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-18",
+	"tips": "Bonus $30 hanya masuk kalau kamu mendaftar memakai kode undangan; tanpa kode undangan saldo awal cuma $50. Kredit ini cepat susut karena diskon prompt caching tidak diterapkan: pada pengujian 18 Agustus 2026 satu permintaan berisi 21.291 token masukan ditagih penuh $0,32 dengan tarif Claude Opus 5 $15 per 1 juta token masukan dan $15 per 1 juta token keluaran, sehingga satu sesi agen pengoding yang panjang bisa menghabiskan saldo dalam hitungan jam. Tidak ada check-in harian, jadi saldo tidak bertambah setelah bonus awal. Domain baru terdaftar 3 Agustus 2026 dan instance-nya masih menampilkan versi v1.0.0 dengan monitor uptime kosong, jadi jangan pakai untuk beban kerja produksi dan jangan kirim data sensitif; permintaan dirakit ulang di sisi server gateway dan pada pengujian yang sama ada blok instruksi tambahan yang ikut tersisip ke dalam percakapan.",
+	"source": "https://godrouter.cyou/pricing",
+	"contributorSlug": "syafii-fahreza"
+}

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-17",
-	"total": 100,
+	"total": 101,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -339,6 +339,16 @@
 			"featured": false,
 			"publishedAt": "2026-06-17",
 			"contributorSlug": "wauputr4"
+		},
+		{
+			"id": "godrouter-free-50-credit",
+			"title": "God Router Free $50 AI Credit + $30 Bonus Referral",
+			"provider": "God Router",
+			"status": "active",
+			"tags": ["AI Credits", "API", "AI Tools", "Free Tier", "Developer Tools"],
+			"featured": false,
+			"publishedAt": "2026-08-18",
+			"contributorSlug": "syafii-fahreza"
 		},
 		{
 			"id": "google-ai-pro-4-bulan",


### PR DESCRIPTION
## Ringkasan

Menambahkan listing `godrouter-free-50-credit` — God Router (`godrouter.cyou`), gateway AI kompatibel OpenAI berbasis New API dengan 26 model.

Struktur bonusnya sengaja dipecah di judul supaya tidak menyesatkan:

- `新用户注册赠送 $50` — diterima **semua** akun baru
- `使用邀请码赠送 $30` — tambahan khusus **pendaftar** yang memakai kode undangan

Jadi saldo awal lewat tautan referral $80, tetapi tanpa kode undangan hanya $50. Ini pola yang sama seperti Vyce AI, bukan seperti Token Harbor (di mana kode undangan hanya menguntungkan pengundang). Fakta itu ditulis eksplisit di `description`, `benefits`, `requirements`, dan `tips`.

## Bukti

Nilai bonus **tidak diumumkan di halaman mana pun** — `/api/status` tidak mengekspos `quota_for_new_user`/`quota_for_invitee`, `announcements` hanya sapaan branding, dan `/api/notice` kosong. Angkanya hanya muncul di log sistem dashboard setelah akun dibuat (18 Agustus 2026, 14:31 WIB):

```
2026-08-18 13:26:45  System  使用邀请码赠送 ＄30.000000 额度
2026-08-18 13:26:45  System  新用户注册赠送 ＄50.000000 额度
```

Karena itu `source` diarahkan ke halaman harga publik (`/pricing`) yang bisa diperiksa siapa pun, dan `validity.type` diset `uncertain`.

API-nya sudah benar-benar dipanggil sebelum diajukan, bukan hanya dibaca dari halaman promosi. Log pemakaian `claude-opus-5` pada tarif `Standard · $15 / $15/M`:

```
14:31:57  Non-stream  570 / 8        $0,00867
14:31:54  Stream      21.291 / 57    $0,32022
14:31:37  Stream      20.025 / 0     $0,300376
```

## Catatan untuk reviewer

Beberapa hal yang saya anggap wajib disampaikan ke pembaca, semuanya sudah masuk `tips`:

1. **Diskon prompt caching tidak diterapkan.** Permintaan 21.291 token masukan ditagih $0,32022 = tarif penuh $15/1 juta token. Konsekuensinya saldo $80 bisa habis dalam hitungan jam pada sesi agen pengoding yang panjang, jadi angka $80 di sini tidak setara $80 di gateway yang mendukung cache.
2. **Tidak ada check-in harian** (`checkin_enabled: false`), jadi saldo tidak bertambah setelah bonus awal.
3. **Layanan sangat baru.** Domain terdaftar 3 Agustus 2026 (RDAP CentralNic, registrar NicNames), `version: v1.0.0`, `uptime_kuma_enabled: true` tetapi `/api/uptime/status` mengembalikan `data: []`.
4. **Jangan kirim data sensitif.** Permintaan dirakit ulang di sisi server gateway, dan pada pengujian yang sama ada blok instruksi tambahan yang ikut tersisip ke dalam percakapan.

Sisi positifnya: User Agreement dan Privacy Policy tersedia dan tidak melarang membagikan tautan undangan, registrasi terbuka lewat email + OTP tanpa mewajibkan GitHub, dan semua 26 model berada di grup `default` dengan `group_ratio: 1` sehingga akun baru langsung bisa memakai semuanya.

Tidak ada listing God Router sebelumnya di katalog. `gorouter-free-75-ai-credit` adalah penyedia lain (domain `gorouter.app`) — bukan duplikat.

## Validasi

- `npm run validate:data` → `Validated 101 bansos folders and contributor references`
- `prettier --check` pada berkas yang disentuh → `All matched files use Prettier code style!`
- `svelte-check --threshold error` → `382 FILES 0 ERRORS 0 WARNINGS`
- `src/lib/data/bansos/commit-history.json` sengaja dikembalikan ke keadaan upstream agar diff tetap fokus

Kontributor: `syafii-fahreza` (profil sudah ada, hanya `contributedBansos` yang ditambah).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new God Router promotional offer featuring $50 in signup credits and a potential $30 referral bonus.
  * Included details about supported AI models, registration requirements, API access, usage costs, validity, and security considerations.
  * Expanded the available promotions catalog to 101 entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->