### PR TITLE
Add AgentRouter $50 referral credit listing

### DIFF
--- a/src/lib/data/bansos/agentrouter-free-150-credit/README.md
+++ b/src/lib/data/bansos/agentrouter-free-150-credit/README.md
@@ -1,10 +1,10 @@
-# ✅ AgentRouter Free $150 AI Credit + $25 Daily Reward
+# ❌ AgentRouter Free $150 AI Credit + $25 Daily Reward
 
 **Provider:** [AgentRouter](https://agent-router.org)
 
 AgentRouter memberikan bonus AI Credit sebesar $150 untuk pengguna baru yang mendaftar melalui program yang tersedia. Pengguna juga berkesempatan memperoleh tambahan AI Credit harian sesuai ketentuan program. Credit dapat digunakan untuk mengakses berbagai model AI melalui satu API.
 
-> **Status:** Aktif
+> **Status:** Kadaluwarsa
 
 ⏰ **Info Waktu:** Berlaku selama program promosi masih tersedia
 

--- a/src/lib/data/bansos/agentrouter-free-150-credit/index.json
+++ b/src/lib/data/bansos/agentrouter-free-150-credit/index.json
@@ -19,7 +19,7 @@
 	},
 	"ctaLink": "https://agentrouter.org/register?aff=txsb",
 	"tags": ["AI", "AI Credits", "API", "Developer Tools"],
-	"status": "active",
+	"status": "expired",
 	"featured": false,
 	"tips": "Gunakan akun GitHub yang aktif dan hindari membuat akun ganda agar tetap sesuai Terms of Service",
 	"publishedAt": "2026-07-13",

--- a/src/lib/data/bansos/agentrouter-free-50-credit-daily-checkin/README.md
+++ b/src/lib/data/bansos/agentrouter-free-50-credit-daily-checkin/README.md
@@ -1,0 +1,38 @@
+# ✅ AgentRouter $50 New User Credit + $25 Daily Check-in
+
+**Provider:** AgentRouter
+
+AgentRouter memberikan $50 AI credit kepada pengguna baru yang mendaftar melalui link referral. Pengguna juga dapat memperoleh $25 credit melalui check-in harian untuk memakai berbagai model AI lewat API.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Kampanye provider diumumkan sampai awal September; tanggal berakhir yang tepat belum diumumkan
+
+## Keuntungan
+
+- $50 AI credit untuk pengguna baru
+- $25 AI credit dari check-in harian
+- Akses berbagai model AI melalui API
+
+## Persyaratan
+
+- Daftar sebagai pengguna baru melalui link referral
+- Login dan lakukan check-in harian untuk klaim credit
+- Gunakan layanan secara wajar dan patuhi larangan akun ganda, otomatisasi abuse, serta penjualan kembali credit
+
+## Tips
+
+Ketersediaan dan nominal reward dapat berubah; cek pengumuman resmi AgentRouter sebelum klaim.
+
+---
+
+[🔗 Klaim Bansos Ini](https://agentrouter.org/register?aff=71vb)
+
+
+🏷️ Tags: AI · AI Credits · API · Developer Tools · Referral
+
+✏️ Dikontribusikan oleh `ikan`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/agentrouter-free-50-credit-daily-checkin/index.json
+++ b/src/lib/data/bansos/agentrouter-free-50-credit-daily-checkin/index.json
@@ -1,0 +1,28 @@
+{
+	"id": "agentrouter-free-50-credit-daily-checkin",
+	"title": "AgentRouter $50 New User Credit + $25 Daily Check-in",
+	"provider": "AgentRouter",
+	"description": "AgentRouter memberikan $50 AI credit kepada pengguna baru yang mendaftar melalui link referral. Pengguna juga dapat memperoleh $25 credit melalui check-in harian untuk memakai berbagai model AI lewat API.",
+	"benefits": [
+		"$50 AI credit untuk pengguna baru",
+		"$25 AI credit dari check-in harian",
+		"Akses berbagai model AI melalui API"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Kampanye provider diumumkan sampai awal September; tanggal berakhir yang tepat belum diumumkan"
+	},
+	"requirements": [
+		"Daftar sebagai pengguna baru melalui link referral",
+		"Login dan lakukan check-in harian untuk klaim credit",
+		"Gunakan layanan secara wajar dan patuhi larangan akun ganda, otomatisasi abuse, serta penjualan kembali credit"
+	],
+	"ctaLink": "https://agentrouter.org/register?aff=71vb",
+	"tags": ["AI", "AI Credits", "API", "Developer Tools", "Referral"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-21",
+	"tips": "Ketersediaan dan nominal reward dapat berubah; cek pengumuman resmi AgentRouter sebelum klaim.",
+	"source": "https://agentrouter.org/api/status",
+	"contributorSlug": "ikan"
+}

--- a/src/lib/data/bansos/agentrouter-free-credits/README.md
+++ b/src/lib/data/bansos/agentrouter-free-credits/README.md
@@ -1,4 +1,4 @@
-# ✅ Free $200 Credit API LLM Populer
+# ❌ Free $200 Credit API LLM Populer
 
 **Provider:** AgentRouter
 
@@ -6,7 +6,7 @@ Langsung dapat $200 setelah mendaftar.
 
 Tersedia 10 model LLM yang bisa digunakan melalui API key.
 
-> **Status:** Aktif
+> **Status:** Kadaluwarsa
 
 ## Keuntungan
 

--- a/src/lib/data/bansos/agentrouter-free-credits/index.json
+++ b/src/lib/data/bansos/agentrouter-free-credits/index.json
@@ -10,7 +10,7 @@
 	},
 	"ctaLink": "https://agentrouter.org/register?aff=qdG1",
 	"tags": ["AI Tools", "AI Credits", "API"],
-	"status": "active",
+	"status": "expired",
 	"featured": false,
 	"publishedAt": "2026-06-18",
 	"source": "https://agentrouter.org/register?aff=qdG1",

--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -50,9 +50,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/89b3bc4860a78d9cc861198c7320c70b60ebab3e"
 	},
 	"aisure-free-platform": {
-		"hash": "a1e78a6a924f3a9525b284e0b233e9ee19a1c801",
-		"date": "2026-08-07T03:19:59Z",
-		"url": "https://github.com/wauputr4/bansos/commit/a1e78a6a924f3a9525b284e0b233e9ee19a1c801"
+		"hash": "e9e1863f9d675b4d37b2a61aea59d718b439ecdb",
+		"date": "2026-08-08T15:36:21+08:00",
+		"url": "https://github.com/wauputr4/bansos/commit/e9e1863f9d675b4d37b2a61aea59d718b439ecdb"
 	},
 	"amd-ai-dev-program": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
@@ -73,6 +73,11 @@
 		"hash": "51e6a49c8f8fb90d0141545988ee9afa382cd3fa",
 		"date": "2026-07-06T14:32:42Z",
 		"url": "https://github.com/wauputr4/bansos/commit/51e6a49c8f8fb90d0141545988ee9afa382cd3fa"
+	},
+	"biznetgio-domain-id-rp8100-17-agustus-2026": {
+		"hash": "9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3",
+		"date": "2026-08-17T10:36:03+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3"
 	},
 	"bynara-ai-router-free-payg": {
 		"hash": "bfdc06ff5b677b15ff6850c572676bc98084aec9",
@@ -119,6 +124,11 @@
 		"date": "2026-06-23T23:38:37+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/1157999e5dd65910aa60af5c6510bb7f024a4c12"
 	},
+	"domainesia-domain-id-rp50k-17-agustus-2026": {
+		"hash": "9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3",
+		"date": "2026-08-17T10:36:03+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3"
+	},
 	"free-5-credit-for-new-opencode-go-users": {
 		"hash": "bc739a1e94f5bb7fc5d62d5b25b1746d14901208",
 		"date": "2026-07-30T14:41:35+07:00",
@@ -154,6 +164,11 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"godrouter-free-50-credit": {
+		"hash": "f65841e25286a01b31577a4b2ec6547ec2969c31",
+		"date": "2026-08-18T14:50:21+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/f65841e25286a01b31577a4b2ec6547ec2969c31"
+	},
 	"google-ai-pro-4-bulan": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",
@@ -174,6 +189,26 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"hcnsec-free-30k-api-credit": {
+		"hash": "516c4ee047e78aba39b94ccb6ec2fda77cad087e",
+		"date": "2026-08-10T17:05:07+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/516c4ee047e78aba39b94ccb6ec2fda77cad087e"
+	},
+	"helipod-domain-id-rp45k-hosting-merdeka-2026": {
+		"hash": "cbf29a87e5b54c7adefe6714d1b6947480d0376b",
+		"date": "2026-08-17T11:06:40+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/cbf29a87e5b54c7adefe6714d1b6947480d0376b"
+	},
+	"idcloudhost-cloud-vps-bonus-rp100k-ai-agent-2026": {
+		"hash": "cbf29a87e5b54c7adefe6714d1b6947480d0376b",
+		"date": "2026-08-17T11:06:40+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/cbf29a87e5b54c7adefe6714d1b6947480d0376b"
+	},
+	"idcloudhost-domain-id-rp50k-17-agustus-2026": {
+		"hash": "cbf29a87e5b54c7adefe6714d1b6947480d0376b",
+		"date": "2026-08-17T11:06:40+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/cbf29a87e5b54c7adefe6714d1b6947480d0376b"
+	},
 	"idwebhost-claim-domain-gratis-myid-juli2026": {
 		"hash": "51071027eb796076f9947b68d64bedabdf4cd70a",
 		"date": "2026-07-03T05:17:11Z",
@@ -184,10 +219,25 @@
 		"date": "2026-06-22T16:08:07+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/0ca2b156a3f1222687071ea265155f8df1c01d64"
 	},
+	"idwebhost-domain-id-rp50k-17-agustus-2026": {
+		"hash": "1e6c2987817b41c64d445fe36ec4d699e15db870",
+		"date": "2026-08-17T09:49:54+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/1e6c2987817b41c64d445fe36ec4d699e15db870"
+	},
 	"inceptionlabs-get-started": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+	},
+	"inferx-deepseek-v4-flash": {
+		"hash": "7079362f5887a4a981c70a0c61b3bd1e70259136",
+		"date": "2026-08-17T00:02:22+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/7079362f5887a4a981c70a0c61b3bd1e70259136"
+	},
+	"jagoanhosting-domain-id-rp50k-merdeka-2026": {
+		"hash": "9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3",
+		"date": "2026-08-17T10:36:03+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3"
 	},
 	"jagoanhosting-free-domain-webid": {
 		"hash": "007aa025444496859f448400ca3a521bba54078e",
@@ -249,6 +299,11 @@
 		"date": "2026-07-11T07:30:53Z",
 		"url": "https://github.com/wauputr4/bansos/commit/899123e3e22d72b8bc5ec1b31565573a8b7c3363"
 	},
+	"modeloc-invite-100k-compute": {
+		"hash": "e7d350a83ce93e7b04197fc3460be3a733b5f65c",
+		"date": "2026-08-16T23:45:37+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/e7d350a83ce93e7b04197fc3460be3a733b5f65c"
+	},
 	"modelset-free-credit": {
 		"hash": "e245ad3e5a04c2e2a5a47a774708f62b65a5374b",
 		"date": "2026-07-23T14:54:13+07:00",
@@ -309,10 +364,15 @@
 		"date": "2026-08-02T18:56:52+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/5c3849b1021c2b54ea66e88142ee970c4ea24793"
 	},
+	"qoder-qwen-38-max-free": {
+		"hash": "7c79f525015e58f1a7303ac591d9667dc9e35785",
+		"date": "2026-08-16T23:59:47+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/7c79f525015e58f1a7303ac591d9667dc9e35785"
+	},
 	"qoder-qwen-max-free": {
-		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
-		"date": "2026-06-21T15:46:56+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+		"hash": "46b085b35e840269fbc8b9e3f119094a7a6269f7",
+		"date": "2026-08-08T14:59:13+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/46b085b35e840269fbc8b9e3f119094a7a6269f7"
 	},
 	"rumahweb-free-domain-xyz": {
 		"hash": "3750e3969354d6594529e80d4e2f5db9ea98dd63",
@@ -339,6 +399,11 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"tabiai-free-120-api-credit": {
+		"hash": "e20770d5536f63a6c7ef1b7c15b0331ecd5c05c9",
+		"date": "2026-08-10T18:18:37+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/e20770d5536f63a6c7ef1b7c15b0331ecd5c05c9"
+	},
 	"tencent-cloud-free-tier": {
 		"hash": "194a0cc681b65d20ddd9c5bb70f1485bd9506af4",
 		"date": "2026-07-22T11:38:06+07:00",
@@ -353,6 +418,11 @@
 		"hash": "e245ad3e5a04c2e2a5a47a774708f62b65a5374b",
 		"date": "2026-07-23T14:54:13+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/e245ad3e5a04c2e2a5a47a774708f62b65a5374b"
+	},
+	"tokenharbor-free-5-credit": {
+		"hash": "8371481616e6f62eeea893c621db56c5bf6f26ed",
+		"date": "2026-08-10T18:44:58+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/8371481616e6f62eeea893c621db56c5bf6f26ed"
 	},
 	"tokenrouter-minimax-m3-free": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
@@ -394,15 +464,30 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"xiaomi-mimo-api-key-gratis": {
+		"hash": "3fdcbe6500a73abc59a45d33df35701f04c30a14",
+		"date": "2026-08-17T00:05:55+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/3fdcbe6500a73abc59a45d33df35701f04c30a14"
+	},
 	"xiaomi-mimo-gratis-2": {
-		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
-		"date": "2026-06-21T15:46:56+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+		"hash": "8da4b2fde10b40001fabf23731976be238a7696c",
+		"date": "2026-08-08T17:42:43+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/8da4b2fde10b40001fabf23731976be238a7696c"
+	},
+	"xkiro-pro-7-hari": {
+		"hash": "54f3b66abe8b7ef666b5256b3cca024d4d839cbb",
+		"date": "2026-08-17T00:07:15+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/54f3b66abe8b7ef666b5256b3cca024d4d839cbb"
 	},
 	"zcode-glm-52-free": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+	},
+	"zenhosta-domain-id-rp50k-merdeka-2026": {
+		"hash": "1e6c2987817b41c64d445fe36ec4d699e15db870",
+		"date": "2026-08-17T09:49:54+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/1e6c2987817b41c64d445fe36ec4d699e15db870"
 	},
 	"zenhosta-gratis-domain-1-tahun": {
 		"hash": "03fe9d37bf86316938352347f78be2cf5612c8ff",

--- a/src/lib/data/bansos/contributors/ikan/manifest.json
+++ b/src/lib/data/bansos/contributors/ikan/manifest.json
@@ -7,7 +7,10 @@
 	"links": {
 		"github": "https://github.com/Aldii24"
 	},
-	"contributedBansos": ["freemodel-pro-plan-bonus-referral-ikan"],
+	"contributedBansos": [
+		"agentrouter-free-50-credit-daily-checkin",
+		"freemodel-pro-plan-bonus-referral-ikan"
+	],
 	"hidden": false,
 	"joinedAt": "2026-07-14"
 }

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-17",
-	"total": 101,
+	"total": 102,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -36,7 +36,7 @@
 			"id": "agentrouter-free-150-credit",
 			"title": "AgentRouter Free $150 AI Credit + $25 Daily Reward",
 			"provider": "AgentRouter",
-			"status": "active",
+			"status": "expired",
 			"tags": ["AI", "AI Credits", "API", "Developer Tools"],
 			"featured": false,
 			"publishedAt": "2026-07-13",
@@ -53,10 +53,20 @@
 			"contributorSlug": "jovian"
 		},
 		{
+			"id": "agentrouter-free-50-credit-daily-checkin",
+			"title": "AgentRouter $50 New User Credit + $25 Daily Check-in",
+			"provider": "AgentRouter",
+			"status": "active",
+			"tags": ["AI", "AI Credits", "API", "Developer Tools", "Referral"],
+			"featured": false,
+			"publishedAt": "2026-08-21",
+			"contributorSlug": "ikan"
+		},
+		{
 			"id": "agentrouter-free-credits",
 			"title": "Free $200 Credit API LLM Populer",
 			"provider": "AgentRouter",
-			"status": "active",
+			"status": "expired",
 			"tags": ["AI Tools", "AI Credits", "API"],
 			"featured": false,
 			"publishedAt": "2026-06-18",


### PR DESCRIPTION
## Summary
- add AgentRouter referral listing for $50 new-user credit and $25 daily check-in
- use official AgentRouter status endpoint as source evidence
- expire older AgentRouter referral listings according to the one-month referral rotation rule
- attribute the listing to contributor `ikan` / `Aldii24`

## Source
- CTA: https://agentrouter.org/register?aff=71vb
- Official status: https://agentrouter.org/api/status

The official status endpoint confirms a $50 new-user reward, $25 daily check-in, and a campaign running until early September with no exact end date published.

## Validation
- `npm run validate:data`
- `npm run check`
- targeted Prettier check: passed
- `npm run lint`: existing repository-wide formatting warnings (219 baseline files)
- `npm run build`: prerender reaches listing routes but stops on pre-existing `/aldi/` 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an active AgentRouter promotion offering referral and daily check-in credits.
  * Updated the promotions catalog and contributor listings to include the new offer.

* **Updates**
  * Marked two existing AgentRouter credit promotions as expired.
  * Expanded promotional metadata and refreshed related catalog records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->