### PR TITLE
feat: add JustWoker Free $90 AI API Credit

### DIFF
--- a/src/lib/data/bansos/commit-history.json
+++ b/src/lib/data/bansos/commit-history.json
@@ -50,9 +50,9 @@
 		"url": "https://github.com/wauputr4/bansos/commit/89b3bc4860a78d9cc861198c7320c70b60ebab3e"
 	},
 	"aisure-free-platform": {
-		"hash": "a1e78a6a924f3a9525b284e0b233e9ee19a1c801",
-		"date": "2026-08-07T03:19:59Z",
-		"url": "https://github.com/wauputr4/bansos/commit/a1e78a6a924f3a9525b284e0b233e9ee19a1c801"
+		"hash": "e9e1863f9d675b4d37b2a61aea59d718b439ecdb",
+		"date": "2026-08-08T15:36:21+08:00",
+		"url": "https://github.com/wauputr4/bansos/commit/e9e1863f9d675b4d37b2a61aea59d718b439ecdb"
 	},
 	"amd-ai-dev-program": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
@@ -73,6 +73,11 @@
 		"hash": "51e6a49c8f8fb90d0141545988ee9afa382cd3fa",
 		"date": "2026-07-06T14:32:42Z",
 		"url": "https://github.com/wauputr4/bansos/commit/51e6a49c8f8fb90d0141545988ee9afa382cd3fa"
+	},
+	"biznetgio-domain-id-rp8100-17-agustus-2026": {
+		"hash": "9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3",
+		"date": "2026-08-17T10:36:03+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3"
 	},
 	"bynara-ai-router-free-payg": {
 		"hash": "bfdc06ff5b677b15ff6850c572676bc98084aec9",
@@ -119,6 +124,11 @@
 		"date": "2026-06-23T23:38:37+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/1157999e5dd65910aa60af5c6510bb7f024a4c12"
 	},
+	"domainesia-domain-id-rp50k-17-agustus-2026": {
+		"hash": "9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3",
+		"date": "2026-08-17T10:36:03+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3"
+	},
 	"free-5-credit-for-new-opencode-go-users": {
 		"hash": "bc739a1e94f5bb7fc5d62d5b25b1746d14901208",
 		"date": "2026-07-30T14:41:35+07:00",
@@ -154,6 +164,11 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"godrouter-free-50-credit": {
+		"hash": "f65841e25286a01b31577a4b2ec6547ec2969c31",
+		"date": "2026-08-18T14:50:21+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/f65841e25286a01b31577a4b2ec6547ec2969c31"
+	},
 	"google-ai-pro-4-bulan": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",
@@ -174,6 +189,26 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"hcnsec-free-30k-api-credit": {
+		"hash": "516c4ee047e78aba39b94ccb6ec2fda77cad087e",
+		"date": "2026-08-10T17:05:07+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/516c4ee047e78aba39b94ccb6ec2fda77cad087e"
+	},
+	"helipod-domain-id-rp45k-hosting-merdeka-2026": {
+		"hash": "cbf29a87e5b54c7adefe6714d1b6947480d0376b",
+		"date": "2026-08-17T11:06:40+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/cbf29a87e5b54c7adefe6714d1b6947480d0376b"
+	},
+	"idcloudhost-cloud-vps-bonus-rp100k-ai-agent-2026": {
+		"hash": "cbf29a87e5b54c7adefe6714d1b6947480d0376b",
+		"date": "2026-08-17T11:06:40+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/cbf29a87e5b54c7adefe6714d1b6947480d0376b"
+	},
+	"idcloudhost-domain-id-rp50k-17-agustus-2026": {
+		"hash": "cbf29a87e5b54c7adefe6714d1b6947480d0376b",
+		"date": "2026-08-17T11:06:40+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/cbf29a87e5b54c7adefe6714d1b6947480d0376b"
+	},
 	"idwebhost-claim-domain-gratis-myid-juli2026": {
 		"hash": "51071027eb796076f9947b68d64bedabdf4cd70a",
 		"date": "2026-07-03T05:17:11Z",
@@ -184,10 +219,25 @@
 		"date": "2026-06-22T16:08:07+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/0ca2b156a3f1222687071ea265155f8df1c01d64"
 	},
+	"idwebhost-domain-id-rp50k-17-agustus-2026": {
+		"hash": "1e6c2987817b41c64d445fe36ec4d699e15db870",
+		"date": "2026-08-17T09:49:54+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/1e6c2987817b41c64d445fe36ec4d699e15db870"
+	},
 	"inceptionlabs-get-started": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+	},
+	"inferx-deepseek-v4-flash": {
+		"hash": "7079362f5887a4a981c70a0c61b3bd1e70259136",
+		"date": "2026-08-17T00:02:22+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/7079362f5887a4a981c70a0c61b3bd1e70259136"
+	},
+	"jagoanhosting-domain-id-rp50k-merdeka-2026": {
+		"hash": "9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3",
+		"date": "2026-08-17T10:36:03+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/9f681f96e2cdd87d5fa38b09c74c4cd2ea4bf7e3"
 	},
 	"jagoanhosting-free-domain-webid": {
 		"hash": "007aa025444496859f448400ca3a521bba54078e",
@@ -249,6 +299,11 @@
 		"date": "2026-07-11T07:30:53Z",
 		"url": "https://github.com/wauputr4/bansos/commit/899123e3e22d72b8bc5ec1b31565573a8b7c3363"
 	},
+	"modeloc-invite-100k-compute": {
+		"hash": "e7d350a83ce93e7b04197fc3460be3a733b5f65c",
+		"date": "2026-08-16T23:45:37+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/e7d350a83ce93e7b04197fc3460be3a733b5f65c"
+	},
 	"modelset-free-credit": {
 		"hash": "e245ad3e5a04c2e2a5a47a774708f62b65a5374b",
 		"date": "2026-07-23T14:54:13+07:00",
@@ -309,10 +364,15 @@
 		"date": "2026-08-02T18:56:52+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/5c3849b1021c2b54ea66e88142ee970c4ea24793"
 	},
+	"qoder-qwen-38-max-free": {
+		"hash": "7c79f525015e58f1a7303ac591d9667dc9e35785",
+		"date": "2026-08-16T23:59:47+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/7c79f525015e58f1a7303ac591d9667dc9e35785"
+	},
 	"qoder-qwen-max-free": {
-		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
-		"date": "2026-06-21T15:46:56+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+		"hash": "46b085b35e840269fbc8b9e3f119094a7a6269f7",
+		"date": "2026-08-08T14:59:13+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/46b085b35e840269fbc8b9e3f119094a7a6269f7"
 	},
 	"rumahweb-free-domain-xyz": {
 		"hash": "3750e3969354d6594529e80d4e2f5db9ea98dd63",
@@ -339,6 +399,11 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"tabiai-free-120-api-credit": {
+		"hash": "e20770d5536f63a6c7ef1b7c15b0331ecd5c05c9",
+		"date": "2026-08-10T18:18:37+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/e20770d5536f63a6c7ef1b7c15b0331ecd5c05c9"
+	},
 	"tencent-cloud-free-tier": {
 		"hash": "194a0cc681b65d20ddd9c5bb70f1485bd9506af4",
 		"date": "2026-07-22T11:38:06+07:00",
@@ -353,6 +418,11 @@
 		"hash": "e245ad3e5a04c2e2a5a47a774708f62b65a5374b",
 		"date": "2026-07-23T14:54:13+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/e245ad3e5a04c2e2a5a47a774708f62b65a5374b"
+	},
+	"tokenharbor-free-5-credit": {
+		"hash": "8371481616e6f62eeea893c621db56c5bf6f26ed",
+		"date": "2026-08-10T18:44:58+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/8371481616e6f62eeea893c621db56c5bf6f26ed"
 	},
 	"tokenrouter-minimax-m3-free": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
@@ -394,15 +464,30 @@
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
 	},
+	"xiaomi-mimo-api-key-gratis": {
+		"hash": "3fdcbe6500a73abc59a45d33df35701f04c30a14",
+		"date": "2026-08-17T00:05:55+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/3fdcbe6500a73abc59a45d33df35701f04c30a14"
+	},
 	"xiaomi-mimo-gratis-2": {
-		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
-		"date": "2026-06-21T15:46:56+07:00",
-		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+		"hash": "8da4b2fde10b40001fabf23731976be238a7696c",
+		"date": "2026-08-08T17:42:43+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/8da4b2fde10b40001fabf23731976be238a7696c"
+	},
+	"xkiro-pro-7-hari": {
+		"hash": "54f3b66abe8b7ef666b5256b3cca024d4d839cbb",
+		"date": "2026-08-17T00:07:15+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/54f3b66abe8b7ef666b5256b3cca024d4d839cbb"
 	},
 	"zcode-glm-52-free": {
 		"hash": "50cf8959b23628c12cb1b9ffcc55ba3aea77def9",
 		"date": "2026-06-21T15:46:56+07:00",
 		"url": "https://github.com/wauputr4/bansos/commit/50cf8959b23628c12cb1b9ffcc55ba3aea77def9"
+	},
+	"zenhosta-domain-id-rp50k-merdeka-2026": {
+		"hash": "1e6c2987817b41c64d445fe36ec4d699e15db870",
+		"date": "2026-08-17T09:49:54+07:00",
+		"url": "https://github.com/wauputr4/bansos/commit/1e6c2987817b41c64d445fe36ec4d699e15db870"
 	},
 	"zenhosta-gratis-domain-1-tahun": {
 		"hash": "03fe9d37bf86316938352347f78be2cf5612c8ff",

--- a/src/lib/data/bansos/contributors/milzamsz/README.md
+++ b/src/lib/data/bansos/contributors/milzamsz/README.md
@@ -1,0 +1,3 @@
+# Milzam
+
+Kontributor komunitas [bansos.dev](https://bansos.dev).

--- a/src/lib/data/bansos/contributors/milzamsz/manifest.json
+++ b/src/lib/data/bansos/contributors/milzamsz/manifest.json
@@ -1,0 +1,13 @@
+{
+	"login": "milzamsz",
+	"displayName": "Milzam",
+	"bio": "",
+	"title": "",
+	"skills": [],
+	"links": {
+		"github": "https://github.com/milzamsz"
+	},
+	"contributedBansos": ["justwoker-free-90-credit"],
+	"hidden": false,
+	"joinedAt": "2026-08-21"
+}

--- a/src/lib/data/bansos/contributors/milzamsz/manifest.json
+++ b/src/lib/data/bansos/contributors/milzamsz/manifest.json
@@ -9,5 +9,5 @@
 	},
 	"contributedBansos": ["justwoker-free-90-credit"],
 	"hidden": false,
-	"joinedAt": "2026-08-21"
+	"joinedAt": "2025-08-21"
 }

--- a/src/lib/data/bansos/index.json
+++ b/src/lib/data/bansos/index.json
@@ -1,6 +1,6 @@
 {
 	"generatedAt": "2026-08-17",
-	"total": 101,
+	"total": 102,
 	"items": [
 		{
 			"id": "adobe-creative-cloud-pro-trial",
@@ -539,6 +539,16 @@
 			"featured": false,
 			"publishedAt": "2026-08-05",
 			"contributorSlug": "wenn-id"
+		},
+		{
+			"id": "justwoker-free-90-credit",
+			"title": "JustWoker Free $90 AI API Credit",
+			"provider": "JustWoker",
+			"status": "active",
+			"tags": ["AI", "AI Credits", "API", "Developer Tools", "Claude"],
+			"featured": false,
+			"publishedAt": "2026-08-22",
+			"contributorSlug": "milzamsz"
 		},
 		{
 			"id": "kie-ai-api-discount-credit",

--- a/src/lib/data/bansos/justwoker-free-90-credit/README.md
+++ b/src/lib/data/bansos/justwoker-free-90-credit/README.md
@@ -1,0 +1,34 @@
+# ✅ JustWoker Free $90 AI API Credit
+
+**Provider:** JustWoker
+
+JustWoker memberikan bonus AI API Credit sebesar $90 untuk pengguna baru yang mendaftar melalui referral link. Credit dapat digunakan untuk mengakses berbagai model AI melalui API, termasuk sejumlah model Anthropic Claude yang tersedia pada platform.
+
+> **Status:** Aktif
+
+⏰ **Info Waktu:** Berlaku selama program referral dan bonus registrasi masih tersedia
+
+## Keuntungan
+
+- $90 AI API Credit untuk pengguna baru
+- Akses berbagai model AI melalui satu API
+- Tersedia model Claude Opus dan Thinking
+
+## Persyaratan
+
+- Membuat akun baru JustWoker
+- Mendaftar melalui referral link yang tersedia
+- Bonus mengikuti ketentuan program referral yang sedang berlaku
+
+---
+
+[🔗 Klaim Bansos Ini](https://api.justwoker.icu/sign-up?aff=GrQG&utm_source=bansos.dev&utm_medium=referral&utm_campaign=bansos)
+
+
+🏷️ Tags: AI · AI Credits · API · Developer Tools · Claude
+
+✏️ Dikontribusikan oleh `milzamsz`
+
+---
+
+*[bansos.dev](https://bansos.dev) — Open Source Catalog*

--- a/src/lib/data/bansos/justwoker-free-90-credit/index.json
+++ b/src/lib/data/bansos/justwoker-free-90-credit/index.json
@@ -1,0 +1,27 @@
+{
+	"id": "justwoker-free-90-credit",
+	"title": "JustWoker Free $90 AI API Credit",
+	"provider": "JustWoker",
+	"description": "JustWoker memberikan bonus AI API Credit sebesar $90 untuk pengguna baru yang mendaftar melalui referral link. Credit dapat digunakan untuk mengakses berbagai model AI melalui API, termasuk sejumlah model Anthropic Claude yang tersedia pada platform.",
+	"benefits": [
+		"$90 AI API Credit untuk pengguna baru",
+		"Akses berbagai model AI melalui satu API",
+		"Tersedia model Claude Opus dan Thinking"
+	],
+	"validity": {
+		"type": "uncertain",
+		"description": "Berlaku selama program referral dan bonus registrasi masih tersedia"
+	},
+	"requirements": [
+		"Membuat akun baru JustWoker",
+		"Mendaftar melalui referral link yang tersedia",
+		"Bonus mengikuti ketentuan program referral yang sedang berlaku"
+	],
+	"ctaLink": "https://api.justwoker.icu/sign-up?aff=GrQG&utm_source=bansos.dev&utm_medium=referral&utm_campaign=bansos",
+	"tags": ["AI", "AI Credits", "API", "Developer Tools", "Claude"],
+	"status": "active",
+	"featured": false,
+	"publishedAt": "2026-08-22",
+	"source": "https://api.justwoker.icu/sign-up?aff=GrQG",
+	"contributorSlug": "milzamsz"
+}


### PR DESCRIPTION
Added JustWoker Free $90 AI API Credit to bansos list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new active JustWoker promotion offering $90 in AI API credits, including access to select AI models.
  - Expanded the offers catalog with 16 additional hosting, domain, AI-credit, API-credit, and model promotions.
  - Increased the total number of listed offers from 101 to 102.
  - Added contributor attribution and profile details for Milzam.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->